### PR TITLE
updates readme to remove PoC terms, updates naming convention for KIC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# PoC: Inventory Resource Consumer
+# Kessel Inventory Consumer
 
-### To Build: 
+The Kessel Inventory Consumer (KIC) is a standalone dedicated Kafka consumer group used to expose an eventing based entry point to the Kessel Inventory API. Its purpose is to subscribe to Service Provider owned Kafka topics and ensure reporter resource updates are replicated to Inventory API through events.
+
+### To Build:
 `make local-build`
 
 ### To Build Container Image:
@@ -21,7 +23,7 @@ make build-push-minimal
 
 ### To Run:
 
-Prerequisites: You need to have the basic kafka setup deployed in order to test. You can use the [split setup](https://github.com/project-kessel/inventory-api/blob/main/docs/dev-guides/docker-compose-options.md#local-kessel-inventory--docker-compose-infra-split-setup) target in Inventory API to setup the backend services
+Prerequisites: You need to have the basic kafka setup deployed in order to test. You can use any of the docker compose options ([standard](https://github.com/project-kessel/inventory-api/tree/main?tab=readme-ov-file#running-locally-using-docker-compose) or [more elaborate](https://github.com/project-kessel/inventory-api/blob/main/docs/dev-guides/docker-compose-options.md)) in Inventory API to setup the backend services, including Kafka
 
 **Using local binary**
 
@@ -49,8 +51,8 @@ oc apply -f https://gist.githubusercontent.com/akoserwal/a061a2959862caa653aa8c8
 # Kick the relations pod to load the new schema
 oc delete pod -l app=kessel-relations
 
-# Deploy IRC
-oc process --local -f deploy/kessel-irc-ephem.yaml -p ENV_NAME="YOUR-EPHEMEARL-ENV-NAME" -p IRC_IMAGE="YOUR-QUAY-IMAGE" -p IMAGE_TAG="YOUR-IMAGE-TAG" | oc apply -f-
+# Deploy KIC
+oc process --local -f deploy/kessel-inventory-consumer-ephem.yaml -p ENV_NAME="YOUR-EPHEMERAL-ENV-NAME" -p KIC_IMAGE="YOUR-QUAY-IMAGE" -p IMAGE_TAG="YOUR-IMAGE-TAG" | oc apply -f-
 
 # To test in Ephemeral you need to produce a message to the topic for the consumer to create the resource
 # You can test with my personal kcat image

--- a/deploy/kessel-inventory-consumer-ephem.yaml
+++ b/deploy/kessel-inventory-consumer-ephem.yaml
@@ -1,16 +1,16 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: kessel-irc
+  name: kessel-inventory-consumer
 objects:
   - apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: irc-config
+      name: kic-config
     data:
-      irc-config.yaml: |
+      kic-config.yaml: |
         consumer:
-          topics: 
+          topics:
           - hbi.replication.events
           - host-inventory.hbi.hosts
           retry-options:
@@ -30,7 +30,7 @@ objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
     metadata:
-      name: kessel-irc
+      name: kessel-inventory-consumer
     spec:
       envName: ${ENV_NAME}
       kafkaTopics:
@@ -47,7 +47,7 @@ objects:
         - name: service
           replicas: ${{REPLICAS}}
           podSpec:
-            image: ${IRC_IMAGE}:${IMAGE_TAG}
+            image: ${KIC_IMAGE}:${IMAGE_TAG}
             imagePullPolicy: Always
             command: ["inventory-consumer"]
             args: ["start"]
@@ -55,14 +55,14 @@ objects:
             - name: CLOWDER_ENABLED
               value: "true"
             - name: INVENTORY_CONSUMER_CONFIG
-              value: "/inventory/irc-config.yaml"
+              value: "/inventory/kic-config.yaml"
             volumeMounts:
                 - name: config-volume
                   mountPath: "/inventory"
             volumes:
               - name: config-volume
                 configMap:
-                  name: irc-config
+                  name: kic-config
           webServices:
             public:
               enabled: false
@@ -72,7 +72,7 @@ parameters:
     name: ENV_NAME
     required: true
   - description: App Image
-    name: IRC_IMAGE
+    name: KIC_IMAGE
     value: quay.io/anatale/inventory-resource-consumer
   - description: Image Tag
     name: IMAGE_TAG


### PR DESCRIPTION
* Updates the readme to remove any PoC connotations after migrating code
* Updates clowder deployment and configs to reflect Kessel Inventory Consumer vs Inventory Resource Consumer