### PR TITLE
updates topic names for expected HBI host migration and outbox

### DIFF
--- a/deploy/kessel-inventory-consumer-ephem.yaml
+++ b/deploy/kessel-inventory-consumer-ephem.yaml
@@ -11,7 +11,7 @@ objects:
       kic-config.yaml: |
         consumer:
           topics:
-          - hbi.replication.events
+          - outbox.event.hbi.hosts
           - host-inventory.hbi.hosts
           retry-options:
             consumer-max-retries: 3
@@ -34,7 +34,7 @@ objects:
     spec:
       envName: ${ENV_NAME}
       kafkaTopics:
-      - topicName: hbi.replication.events
+      - topicName: outbox.event.hbi.hosts
         partitions: 3
         replicas: 3
       - topicName: host-inventory.hbi.hosts


### PR DESCRIPTION
Updates the topics in both KIC config and ClowdApp to ensure both migration and outbox topics are set and for bootstrap server injection