### PR TITLE
adds scripts, process, and everything needed to test  locally including HBI migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,19 @@ docker-build-push:
 .PHONY: build-push-minimal
 build-push-minimal:
 	./build_push_minimal.sh
+
+.PHONY: inventory-consumer-up
+inventory-consumer-up:
+	./scripts/start-inventory-consumer.sh full-setup
+
+.PHONY: inventory-consumer-down
+inventory-consumer-down:
+	./scripts/stop-inventory-consumer.sh
+
+.PHONY: setup-hbi-db
+setup-hbi-db:
+	PGPASSWORD=supersecurewow psql -h localhost -p 5432 -U postgres -d host-inventory -f development/configs/hbi-full-setup.sql
+
+.PHONY: setup-migration-connector
+setup-migration-connector:
+	curl -d @development/configs/debezium-connector.json -H 'Content-Type: application/json' -X POST http://localhost:8084/connectors

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ make build-push-minimal
 
 Prerequisites: You need to have the basic kafka setup deployed in order to test. You can use any of the docker compose options ([standard](https://github.com/project-kessel/inventory-api/tree/main?tab=readme-ov-file#running-locally-using-docker-compose) or [more elaborate](https://github.com/project-kessel/inventory-api/blob/main/docs/dev-guides/docker-compose-options.md)) in Inventory API to setup the backend services, including Kafka
 
-**Using local binary**
+#### Using local binary
 
 ```shell
 make build
@@ -37,7 +37,24 @@ make build
 podman run --network kessel -d quay.io/YOUR-IMAGE-HERE:TAG start --consumer.bootstrap-servers kafka:9093
 ```
 
-**Using Ephemeral**
+#### Using Podman Compose
+
+>!NOTE
+>The podman compose setup is meant to replicate an ephemeral-like environment locally and requires Inventory API and Relations API to be running by default. You will need both repos cloned down in order to set everything up.
+
+In the root of your cloned Inventory API repo: `make inventory-up-relations-ready`
+
+In the root of your cloned Relations API reo: `make relations-api-up`
+
+Then:
+
+```shell
+# Deploy KIC and related dependencies
+# This will include a test HBI database for now, Kafka Connect cluster and topic creation
+make inventory-consumer-up
+```
+
+#### Using Ephemeral
 
 ```shell
 # Deploy Kessel Services (this will also deploy relations and inventory api)

--- a/development/configs/debezium-connector.json
+++ b/development/configs/debezium-connector.json
@@ -1,0 +1,30 @@
+{
+  "name": "hbi-migration-connector",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "slot.name": "debezium_hosts",
+    "database.server.name": "host-inventory-db",
+    "database.dbname": "host-inventory",
+    "database.hostname": "hbidatabase",
+    "database.port": "5432",
+    "database.user": "postgres",
+    "database.password": "supersecurewow",
+    "topic.prefix": "host-inventory",
+    "table.include.list": "hbi.hosts",
+    "plugin.name": "pgoutput",
+    "transforms": "unwrap,addMetadata,addHeaders,fieldFilter",
+    "transforms.unwrap.type": "io.debezium.transforms.ExtractNewRecordState",
+    "transforms.unwrap.drop.tombstones": "false",
+    "transforms.unwrap.delete.handling.mode": "rewrite",
+    "transforms.addMetadata.type": "org.apache.kafka.connect.transforms.InsertField$Value",
+    "transforms.addMetadata.static.field": "source_system",
+    "transforms.addMetadata.static.value": "host-inventory-db",
+    "transforms.addHeaders.type": "org.apache.kafka.connect.transforms.InsertHeader",
+    "transforms.addHeaders.header": "operation",
+    "transforms.addHeaders.value.literal": "migration",
+    "transforms.fieldFilter.type": "org.apache.kafka.connect.transforms.ReplaceField$Value",
+    "transforms.fieldFilter.exclude": "deletion_timestamp,facts,last_check_in,modified_on,per_reporter_staleness,stale_timestamp,stale_warning_timestamp,tags,tags_alt",
+    "transforms.fieldFilter.renames": "display_name:hostname,org_id:organization_id"
+  }
+}
+

--- a/development/configs/full-setup.yaml
+++ b/development/configs/full-setup.yaml
@@ -1,0 +1,18 @@
+consumer:
+  bootstrap-servers: ["kafka:9093"]
+  topics:
+  - outbox.event.hbi.hosts
+  - host-inventory.hbi.hosts
+  retry-options:
+    consumer-max-retries: 3
+    operation-max-retries: 4
+    backoff-factor: 5
+  auth:
+    enabled: false
+client:
+  enabled: true
+  url: "inventory-api:9081"
+  enable-oidc-auth: false
+  insecure: true
+log:
+  level: "info"

--- a/development/configs/hbi-full-setup.sql
+++ b/development/configs/hbi-full-setup.sql
@@ -1,0 +1,1290 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 16.4
+-- Dumped by pg_dump version 17.5
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+
+SELECT 'CREATE DATABASE "host-inventory"' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'host-inventory')\gexec
+-- CREATE DATABASE IF NOT EXISTS "host-inventory";
+CREATE ROLE "VBzEIpnveJmm3TXi" with LOGIN PASSWORD 'mypassword';
+GRANT ALL PRIVILEGES on database "host-inventory" to "VBzEIpnveJmm3TXi";
+ALTER ROLE "VBzEIpnveJmm3TXi" with superuser;
+
+--
+-- Name: hbi; Type: SCHEMA; Schema: -; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE SCHEMA hbi;
+
+
+ALTER SCHEMA hbi OWNER TO "VBzEIpnveJmm3TXi";
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: alembic_version; Type: TABLE; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE TABLE hbi.alembic_version (
+    version_num character varying(32) NOT NULL
+);
+
+
+ALTER TABLE hbi.alembic_version OWNER TO "VBzEIpnveJmm3TXi";
+
+--
+-- Name: groups; Type: TABLE; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE TABLE hbi.groups (
+    id uuid NOT NULL,
+    org_id character varying(36) NOT NULL,
+    account character varying(10),
+    name character varying(255) NOT NULL,
+    created_on timestamp with time zone NOT NULL,
+    modified_on timestamp with time zone NOT NULL,
+    ungrouped boolean DEFAULT false NOT NULL
+);
+
+
+ALTER TABLE hbi.groups OWNER TO "VBzEIpnveJmm3TXi";
+
+--
+-- Name: hbi_metadata; Type: TABLE; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE TABLE hbi.hbi_metadata (
+    name character varying NOT NULL,
+    type character varying NOT NULL,
+    last_succeeded timestamp with time zone NOT NULL
+);
+
+
+ALTER TABLE hbi.hbi_metadata OWNER TO "VBzEIpnveJmm3TXi";
+
+--
+-- Name: hosts; Type: TABLE; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE TABLE hbi.hosts (
+    id uuid NOT NULL,
+    account character varying(10),
+    display_name character varying(200),
+    created_on timestamp with time zone NOT NULL,
+    modified_on timestamp with time zone NOT NULL,
+    facts jsonb,
+    tags jsonb,
+    canonical_facts jsonb NOT NULL,
+    system_profile_facts jsonb,
+    ansible_host character varying(255),
+    stale_timestamp timestamp with time zone NOT NULL,
+    reporter character varying(255) NOT NULL,
+    per_reporter_staleness jsonb DEFAULT '{}'::jsonb NOT NULL,
+    org_id character varying(36) NOT NULL,
+    groups jsonb NOT NULL,
+    tags_alt jsonb,
+    last_check_in timestamp with time zone,
+    stale_warning_timestamp timestamp with time zone,
+    deletion_timestamp timestamp with time zone
+);
+
+
+ALTER TABLE hbi.hosts OWNER TO "VBzEIpnveJmm3TXi";
+
+--
+-- Name: hosts_groups; Type: TABLE; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE TABLE hbi.hosts_groups (
+    group_id uuid NOT NULL,
+    host_id uuid NOT NULL
+);
+
+
+ALTER TABLE hbi.hosts_groups OWNER TO "VBzEIpnveJmm3TXi";
+
+--
+-- Name: hosts_groups_new; Type: TABLE; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE TABLE hbi.hosts_groups_new (
+    org_id character varying(36) NOT NULL,
+    host_id uuid NOT NULL,
+    group_id uuid NOT NULL
+)
+PARTITION BY HASH (org_id);
+
+
+ALTER TABLE hbi.hosts_groups_new OWNER TO "VBzEIpnveJmm3TXi";
+
+--
+-- Name: hosts_groups_p0; Type: TABLE; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE TABLE hbi.hosts_groups_p0 (
+    org_id character varying(36) NOT NULL,
+    host_id uuid NOT NULL,
+    group_id uuid NOT NULL
+);
+
+
+ALTER TABLE hbi.hosts_groups_p0 OWNER TO "VBzEIpnveJmm3TXi";
+
+--
+-- Name: hosts_groups_p1; Type: TABLE; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE TABLE hbi.hosts_groups_p1 (
+    org_id character varying(36) NOT NULL,
+    host_id uuid NOT NULL,
+    group_id uuid NOT NULL
+);
+
+
+ALTER TABLE hbi.hosts_groups_p1 OWNER TO "VBzEIpnveJmm3TXi";
+
+--
+-- Name: hosts_new; Type: TABLE; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE TABLE hbi.hosts_new (
+    org_id character varying(36) NOT NULL,
+    id uuid NOT NULL,
+    account character varying(10),
+    display_name character varying(200),
+    ansible_host character varying(255),
+    created_on timestamp with time zone,
+    modified_on timestamp with time zone,
+    facts jsonb,
+    tags jsonb,
+    tags_alt jsonb,
+    system_profile_facts jsonb,
+    groups jsonb NOT NULL,
+    last_check_in timestamp with time zone,
+    stale_timestamp timestamp with time zone NOT NULL,
+    deletion_timestamp timestamp with time zone,
+    stale_warning_timestamp timestamp with time zone,
+    reporter character varying(255) NOT NULL,
+    per_reporter_staleness jsonb NOT NULL,
+    canonical_facts jsonb NOT NULL,
+    canonical_facts_version integer,
+    is_virtual boolean,
+    insights_id uuid DEFAULT '00000000-0000-0000-0000-000000000000'::uuid NOT NULL,
+    subscription_manager_id character varying(36),
+    satellite_id character varying(255),
+    fqdn character varying(255),
+    bios_uuid character varying(36),
+    ip_addresses jsonb,
+    mac_addresses jsonb,
+    provider_id character varying(500),
+    provider_type character varying(50)
+)
+PARTITION BY HASH (org_id);
+
+
+ALTER TABLE hbi.hosts_new OWNER TO "VBzEIpnveJmm3TXi";
+
+--
+-- Name: hosts_p0; Type: TABLE; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE TABLE hbi.hosts_p0 (
+    org_id character varying(36) NOT NULL,
+    id uuid NOT NULL,
+    account character varying(10),
+    display_name character varying(200),
+    ansible_host character varying(255),
+    created_on timestamp with time zone,
+    modified_on timestamp with time zone,
+    facts jsonb,
+    tags jsonb,
+    tags_alt jsonb,
+    system_profile_facts jsonb,
+    groups jsonb NOT NULL,
+    last_check_in timestamp with time zone,
+    stale_timestamp timestamp with time zone NOT NULL,
+    deletion_timestamp timestamp with time zone,
+    stale_warning_timestamp timestamp with time zone,
+    reporter character varying(255) NOT NULL,
+    per_reporter_staleness jsonb NOT NULL,
+    canonical_facts jsonb NOT NULL,
+    canonical_facts_version integer,
+    is_virtual boolean,
+    insights_id uuid DEFAULT '00000000-0000-0000-0000-000000000000'::uuid NOT NULL,
+    subscription_manager_id character varying(36),
+    satellite_id character varying(255),
+    fqdn character varying(255),
+    bios_uuid character varying(36),
+    ip_addresses jsonb,
+    mac_addresses jsonb,
+    provider_id character varying(500),
+    provider_type character varying(50)
+);
+
+
+ALTER TABLE hbi.hosts_p0 OWNER TO "VBzEIpnveJmm3TXi";
+
+--
+-- Name: hosts_p1; Type: TABLE; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE TABLE hbi.hosts_p1 (
+    org_id character varying(36) NOT NULL,
+    id uuid NOT NULL,
+    account character varying(10),
+    display_name character varying(200),
+    ansible_host character varying(255),
+    created_on timestamp with time zone,
+    modified_on timestamp with time zone,
+    facts jsonb,
+    tags jsonb,
+    tags_alt jsonb,
+    system_profile_facts jsonb,
+    groups jsonb NOT NULL,
+    last_check_in timestamp with time zone,
+    stale_timestamp timestamp with time zone NOT NULL,
+    deletion_timestamp timestamp with time zone,
+    stale_warning_timestamp timestamp with time zone,
+    reporter character varying(255) NOT NULL,
+    per_reporter_staleness jsonb NOT NULL,
+    canonical_facts jsonb NOT NULL,
+    canonical_facts_version integer,
+    is_virtual boolean,
+    insights_id uuid DEFAULT '00000000-0000-0000-0000-000000000000'::uuid NOT NULL,
+    subscription_manager_id character varying(36),
+    satellite_id character varying(255),
+    fqdn character varying(255),
+    bios_uuid character varying(36),
+    ip_addresses jsonb,
+    mac_addresses jsonb,
+    provider_id character varying(500),
+    provider_type character varying(50)
+);
+
+
+ALTER TABLE hbi.hosts_p1 OWNER TO "VBzEIpnveJmm3TXi";
+
+--
+-- Name: staleness; Type: TABLE; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE TABLE hbi.staleness (
+    id uuid NOT NULL,
+    org_id character varying(36) NOT NULL,
+    conventional_time_to_stale integer NOT NULL,
+    conventional_time_to_stale_warning integer NOT NULL,
+    conventional_time_to_delete integer NOT NULL,
+    immutable_time_to_stale integer NOT NULL,
+    immutable_time_to_stale_warning integer NOT NULL,
+    immutable_time_to_delete integer NOT NULL,
+    created_on timestamp with time zone NOT NULL,
+    modified_on timestamp with time zone NOT NULL
+);
+
+
+ALTER TABLE hbi.staleness OWNER TO "VBzEIpnveJmm3TXi";
+
+--
+-- Name: hosts_groups_p0; Type: TABLE ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hosts_groups_new ATTACH PARTITION hbi.hosts_groups_p0 FOR VALUES WITH (modulus 2, remainder 0);
+
+
+--
+-- Name: hosts_groups_p1; Type: TABLE ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hosts_groups_new ATTACH PARTITION hbi.hosts_groups_p1 FOR VALUES WITH (modulus 2, remainder 1);
+
+
+--
+-- Name: hosts_p0; Type: TABLE ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hosts_new ATTACH PARTITION hbi.hosts_p0 FOR VALUES WITH (modulus 2, remainder 0);
+
+
+--
+-- Name: hosts_p1; Type: TABLE ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hosts_new ATTACH PARTITION hbi.hosts_p1 FOR VALUES WITH (modulus 2, remainder 1);
+
+
+--
+-- Data for Name: alembic_version; Type: TABLE DATA; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+COPY hbi.alembic_version (version_num) FROM stdin;
+28280de3f1ce
+\.
+
+
+--
+-- Data for Name: groups; Type: TABLE DATA; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+COPY hbi.groups (id, org_id, account, name, created_on, modified_on, ungrouped) FROM stdin;
+\.
+
+
+--
+-- Data for Name: hbi_metadata; Type: TABLE DATA; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+COPY hbi.hbi_metadata (name, type, last_succeeded) FROM stdin;
+\.
+
+
+--
+-- Data for Name: hosts; Type: TABLE DATA; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+COPY hbi.hosts (id, account, display_name, created_on, modified_on, facts, tags, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id, groups, tags_alt, last_check_in, stale_warning_timestamp, deletion_timestamp) FROM stdin;
+\.
+
+
+--
+-- Data for Name: hosts_groups; Type: TABLE DATA; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+COPY hbi.hosts_groups (group_id, host_id) FROM stdin;
+\.
+
+
+--
+-- Data for Name: hosts_groups_p0; Type: TABLE DATA; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+COPY hbi.hosts_groups_p0 (org_id, host_id, group_id) FROM stdin;
+\.
+
+
+--
+-- Data for Name: hosts_groups_p1; Type: TABLE DATA; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+COPY hbi.hosts_groups_p1 (org_id, host_id, group_id) FROM stdin;
+\.
+
+
+--
+-- Data for Name: hosts_p0; Type: TABLE DATA; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+COPY hbi.hosts_p0 (org_id, id, account, display_name, ansible_host, created_on, modified_on, facts, tags, tags_alt, system_profile_facts, groups, last_check_in, stale_timestamp, deletion_timestamp, stale_warning_timestamp, reporter, per_reporter_staleness, canonical_facts, canonical_facts_version, is_virtual, insights_id, subscription_manager_id, satellite_id, fqdn, bios_uuid, ip_addresses, mac_addresses, provider_id, provider_type) FROM stdin;
+\.
+
+
+--
+-- Data for Name: hosts_p1; Type: TABLE DATA; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+COPY hbi.hosts_p1 (org_id, id, account, display_name, ansible_host, created_on, modified_on, facts, tags, tags_alt, system_profile_facts, groups, last_check_in, stale_timestamp, deletion_timestamp, stale_warning_timestamp, reporter, per_reporter_staleness, canonical_facts, canonical_facts_version, is_virtual, insights_id, subscription_manager_id, satellite_id, fqdn, bios_uuid, ip_addresses, mac_addresses, provider_id, provider_type) FROM stdin;
+\.
+
+
+--
+-- Data for Name: staleness; Type: TABLE DATA; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+COPY hbi.staleness (id, org_id, conventional_time_to_stale, conventional_time_to_stale_warning, conventional_time_to_delete, immutable_time_to_stale, immutable_time_to_stale_warning, immutable_time_to_delete, created_on, modified_on) FROM stdin;
+\.
+
+
+--
+-- Name: alembic_version alembic_version_pkc; Type: CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.alembic_version
+    ADD CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num);
+
+
+--
+-- Name: groups groups_pkey; Type: CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.groups
+    ADD CONSTRAINT groups_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY hbi.groups REPLICA IDENTITY USING INDEX groups_pkey;
+
+
+--
+-- Name: hbi_metadata hbi_metadata_pkey; Type: CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hbi_metadata
+    ADD CONSTRAINT hbi_metadata_pkey PRIMARY KEY (name, type);
+
+
+--
+-- Name: hosts_groups_new hosts_groups_new_pkey; Type: CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hosts_groups_new
+    ADD CONSTRAINT hosts_groups_new_pkey PRIMARY KEY (org_id, host_id, group_id);
+
+
+--
+-- Name: hosts_groups_p0 hosts_groups_p0_pkey; Type: CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hosts_groups_p0
+    ADD CONSTRAINT hosts_groups_p0_pkey PRIMARY KEY (org_id, host_id, group_id);
+
+
+--
+-- Name: hosts_groups_p1 hosts_groups_p1_pkey; Type: CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hosts_groups_p1
+    ADD CONSTRAINT hosts_groups_p1_pkey PRIMARY KEY (org_id, host_id, group_id);
+
+
+--
+-- Name: hosts_groups hosts_groups_pkey; Type: CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hosts_groups
+    ADD CONSTRAINT hosts_groups_pkey PRIMARY KEY (group_id, host_id);
+
+ALTER TABLE ONLY hbi.hosts_groups REPLICA IDENTITY USING INDEX hosts_groups_pkey;
+
+
+--
+-- Name: hosts_groups hosts_groups_unique_host_id; Type: CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hosts_groups
+    ADD CONSTRAINT hosts_groups_unique_host_id UNIQUE (host_id);
+
+
+--
+-- Name: hosts_new hosts_new_pkey; Type: CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hosts_new
+    ADD CONSTRAINT hosts_new_pkey PRIMARY KEY (org_id, id);
+
+
+--
+-- Name: hosts_p0 hosts_p0_pkey; Type: CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hosts_p0
+    ADD CONSTRAINT hosts_p0_pkey PRIMARY KEY (org_id, id);
+
+
+--
+-- Name: hosts_p1 hosts_p1_pkey; Type: CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hosts_p1
+    ADD CONSTRAINT hosts_p1_pkey PRIMARY KEY (org_id, id);
+
+
+--
+-- Name: hosts hosts_pkey; Type: CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hosts
+    ADD CONSTRAINT hosts_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY hbi.hosts REPLICA IDENTITY USING INDEX hosts_pkey;
+
+
+--
+-- Name: staleness staleness_org_id_key; Type: CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.staleness
+    ADD CONSTRAINT staleness_org_id_key UNIQUE (org_id);
+
+
+--
+-- Name: staleness staleness_pkey; Type: CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.staleness
+    ADD CONSTRAINT staleness_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY hbi.staleness REPLICA IDENTITY USING INDEX staleness_pkey;
+
+
+--
+-- Name: idx_hosts_groups_reverse; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_groups_reverse ON ONLY hbi.hosts_groups_new USING btree (org_id, group_id, host_id);
+
+
+--
+-- Name: hosts_groups_p0_org_id_group_id_host_id_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_groups_p0_org_id_group_id_host_id_idx ON hbi.hosts_groups_p0 USING btree (org_id, group_id, host_id);
+
+
+--
+-- Name: idx_hosts_groups_forward; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_groups_forward ON ONLY hbi.hosts_groups_new USING btree (org_id, host_id, group_id);
+
+
+--
+-- Name: hosts_groups_p0_org_id_host_id_group_id_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_groups_p0_org_id_host_id_group_id_idx ON hbi.hosts_groups_p0 USING btree (org_id, host_id, group_id);
+
+
+--
+-- Name: hosts_groups_p1_org_id_group_id_host_id_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_groups_p1_org_id_group_id_host_id_idx ON hbi.hosts_groups_p1 USING btree (org_id, group_id, host_id);
+
+
+--
+-- Name: hosts_groups_p1_org_id_host_id_group_id_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_groups_p1_org_id_host_id_group_id_idx ON hbi.hosts_groups_p1 USING btree (org_id, host_id, group_id);
+
+
+--
+-- Name: hosts_modified_on_id; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_modified_on_id ON hbi.hosts USING btree (modified_on DESC, id DESC);
+
+
+--
+-- Name: idx_hosts_sap_system; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_sap_system ON ONLY hbi.hosts_new USING btree ((((system_profile_facts ->> 'sap_system'::text))::boolean));
+
+
+--
+-- Name: hosts_p0_bool_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p0_bool_idx ON hbi.hosts_p0 USING btree ((((system_profile_facts ->> 'sap_system'::text))::boolean));
+
+
+--
+-- Name: idx_hosts_canonical_facts_gin; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_canonical_facts_gin ON ONLY hbi.hosts_new USING gin (canonical_facts jsonb_path_ops);
+
+
+--
+-- Name: hosts_p0_canonical_facts_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p0_canonical_facts_idx ON hbi.hosts_p0 USING gin (canonical_facts jsonb_path_ops);
+
+
+--
+-- Name: idx_hosts_host_type; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_host_type ON ONLY hbi.hosts_new USING btree (((system_profile_facts ->> 'host_type'::text)));
+
+
+--
+-- Name: hosts_p0_expr_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p0_expr_idx ON hbi.hosts_p0 USING btree (((system_profile_facts ->> 'host_type'::text)));
+
+
+--
+-- Name: idx_hosts_cf_insights_id; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_cf_insights_id ON ONLY hbi.hosts_new USING btree (((canonical_facts ->> 'insights_id'::text)));
+
+
+--
+-- Name: hosts_p0_expr_idx1; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p0_expr_idx1 ON hbi.hosts_p0 USING btree (((canonical_facts ->> 'insights_id'::text)));
+
+
+--
+-- Name: idx_hosts_cf_subscription_manager_id; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_cf_subscription_manager_id ON ONLY hbi.hosts_new USING btree (((canonical_facts ->> 'subscription_manager_id'::text)));
+
+
+--
+-- Name: hosts_p0_expr_idx2; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p0_expr_idx2 ON hbi.hosts_p0 USING btree (((canonical_facts ->> 'subscription_manager_id'::text)));
+
+
+--
+-- Name: idx_hosts_mssql; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_mssql ON ONLY hbi.hosts_new USING btree (((system_profile_facts ->> 'mssql'::text)));
+
+
+--
+-- Name: hosts_p0_expr_idx3; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p0_expr_idx3 ON hbi.hosts_p0 USING btree (((system_profile_facts ->> 'mssql'::text)));
+
+
+--
+-- Name: idx_hosts_ansible; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_ansible ON ONLY hbi.hosts_new USING btree (((system_profile_facts ->> 'ansible'::text)));
+
+
+--
+-- Name: hosts_p0_expr_idx4; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p0_expr_idx4 ON hbi.hosts_p0 USING btree (((system_profile_facts ->> 'ansible'::text)));
+
+
+--
+-- Name: idx_hosts_operating_system_multi; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_operating_system_multi ON ONLY hbi.hosts_new USING btree ((((system_profile_facts -> 'operating_system'::text) ->> 'name'::text)), ((((system_profile_facts -> 'operating_system'::text) ->> 'major'::text))::integer), ((((system_profile_facts -> 'operating_system'::text) ->> 'minor'::text))::integer), ((system_profile_facts ->> 'host_type'::text)), modified_on, org_id) WHERE ((system_profile_facts -> 'operating_system'::text) IS NOT NULL);
+
+
+--
+-- Name: hosts_p0_expr_int4_int41_expr1_modified_on_org_id_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p0_expr_int4_int41_expr1_modified_on_org_id_idx ON hbi.hosts_p0 USING btree ((((system_profile_facts -> 'operating_system'::text) ->> 'name'::text)), ((((system_profile_facts -> 'operating_system'::text) ->> 'major'::text))::integer), ((((system_profile_facts -> 'operating_system'::text) ->> 'minor'::text))::integer), ((system_profile_facts ->> 'host_type'::text)), modified_on, org_id) WHERE ((system_profile_facts -> 'operating_system'::text) IS NOT NULL);
+
+
+--
+-- Name: idx_hosts_groups_gin; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_groups_gin ON ONLY hbi.hosts_new USING gin (groups);
+
+
+--
+-- Name: hosts_p0_groups_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p0_groups_idx ON hbi.hosts_p0 USING gin (groups);
+
+
+--
+-- Name: idx_hosts_insights_id; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_insights_id ON ONLY hbi.hosts_new USING btree (insights_id);
+
+
+--
+-- Name: hosts_p0_insights_id_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p0_insights_id_idx ON hbi.hosts_p0 USING btree (insights_id);
+
+
+--
+-- Name: idx_hosts_modified_on_id; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_modified_on_id ON ONLY hbi.hosts_new USING btree (modified_on DESC, id DESC);
+
+
+--
+-- Name: hosts_p0_modified_on_id_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p0_modified_on_id_idx ON hbi.hosts_p0 USING btree (modified_on DESC, id DESC);
+
+
+--
+-- Name: idx_hosts_bootc_status; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_bootc_status ON ONLY hbi.hosts_new USING btree (org_id) WHERE ((((system_profile_facts -> 'bootc_status'::text) -> 'booted'::text) ->> 'image_digest'::text) IS NOT NULL);
+
+
+--
+-- Name: hosts_p0_org_id_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p0_org_id_idx ON hbi.hosts_p0 USING btree (org_id) WHERE ((((system_profile_facts -> 'bootc_status'::text) -> 'booted'::text) ->> 'image_digest'::text) IS NOT NULL);
+
+
+--
+-- Name: idx_hosts_host_type_modified_on_org_id; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_host_type_modified_on_org_id ON ONLY hbi.hosts_new USING btree (org_id, modified_on, ((system_profile_facts ->> 'host_type'::text)));
+
+
+--
+-- Name: hosts_p0_org_id_modified_on_expr_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p0_org_id_modified_on_expr_idx ON hbi.hosts_p0 USING btree (org_id, modified_on, ((system_profile_facts ->> 'host_type'::text)));
+
+
+--
+-- Name: idx_hosts_subscription_manager_id; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_hosts_subscription_manager_id ON ONLY hbi.hosts_new USING btree (subscription_manager_id);
+
+
+--
+-- Name: hosts_p0_subscription_manager_id_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p0_subscription_manager_id_idx ON hbi.hosts_p0 USING btree (subscription_manager_id);
+
+
+--
+-- Name: hosts_p1_bool_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p1_bool_idx ON hbi.hosts_p1 USING btree ((((system_profile_facts ->> 'sap_system'::text))::boolean));
+
+
+--
+-- Name: hosts_p1_canonical_facts_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p1_canonical_facts_idx ON hbi.hosts_p1 USING gin (canonical_facts jsonb_path_ops);
+
+
+--
+-- Name: hosts_p1_expr_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p1_expr_idx ON hbi.hosts_p1 USING btree (((system_profile_facts ->> 'host_type'::text)));
+
+
+--
+-- Name: hosts_p1_expr_idx1; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p1_expr_idx1 ON hbi.hosts_p1 USING btree (((canonical_facts ->> 'insights_id'::text)));
+
+
+--
+-- Name: hosts_p1_expr_idx2; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p1_expr_idx2 ON hbi.hosts_p1 USING btree (((canonical_facts ->> 'subscription_manager_id'::text)));
+
+
+--
+-- Name: hosts_p1_expr_idx3; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p1_expr_idx3 ON hbi.hosts_p1 USING btree (((system_profile_facts ->> 'mssql'::text)));
+
+
+--
+-- Name: hosts_p1_expr_idx4; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p1_expr_idx4 ON hbi.hosts_p1 USING btree (((system_profile_facts ->> 'ansible'::text)));
+
+
+--
+-- Name: hosts_p1_expr_int4_int41_expr1_modified_on_org_id_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p1_expr_int4_int41_expr1_modified_on_org_id_idx ON hbi.hosts_p1 USING btree ((((system_profile_facts -> 'operating_system'::text) ->> 'name'::text)), ((((system_profile_facts -> 'operating_system'::text) ->> 'major'::text))::integer), ((((system_profile_facts -> 'operating_system'::text) ->> 'minor'::text))::integer), ((system_profile_facts ->> 'host_type'::text)), modified_on, org_id) WHERE ((system_profile_facts -> 'operating_system'::text) IS NOT NULL);
+
+
+--
+-- Name: hosts_p1_groups_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p1_groups_idx ON hbi.hosts_p1 USING gin (groups);
+
+
+--
+-- Name: hosts_p1_insights_id_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p1_insights_id_idx ON hbi.hosts_p1 USING btree (insights_id);
+
+
+--
+-- Name: hosts_p1_modified_on_id_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p1_modified_on_id_idx ON hbi.hosts_p1 USING btree (modified_on DESC, id DESC);
+
+
+--
+-- Name: hosts_p1_org_id_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p1_org_id_idx ON hbi.hosts_p1 USING btree (org_id) WHERE ((((system_profile_facts -> 'bootc_status'::text) -> 'booted'::text) ->> 'image_digest'::text) IS NOT NULL);
+
+
+--
+-- Name: hosts_p1_org_id_modified_on_expr_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p1_org_id_modified_on_expr_idx ON hbi.hosts_p1 USING btree (org_id, modified_on, ((system_profile_facts ->> 'host_type'::text)));
+
+
+--
+-- Name: hosts_p1_subscription_manager_id_idx; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX hosts_p1_subscription_manager_id_idx ON hbi.hosts_p1 USING btree (subscription_manager_id);
+
+
+--
+-- Name: idx_groups_org_id_name_nocase; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE UNIQUE INDEX idx_groups_org_id_name_nocase ON hbi.groups USING btree (org_id, lower((name)::text));
+
+
+--
+-- Name: idx_host_type; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_host_type ON hbi.hosts USING btree (((system_profile_facts ->> 'host_type'::text)));
+
+
+--
+-- Name: idx_host_type_modified_on_org_id; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_host_type_modified_on_org_id ON hbi.hosts USING btree (org_id, modified_on, ((system_profile_facts ->> 'host_type'::text)));
+
+
+--
+-- Name: idx_operating_system_multi; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idx_operating_system_multi ON hbi.hosts USING btree ((((system_profile_facts -> 'operating_system'::text) ->> 'name'::text)), ((((system_profile_facts -> 'operating_system'::text) ->> 'major'::text))::integer), ((((system_profile_facts -> 'operating_system'::text) ->> 'minor'::text))::integer), ((system_profile_facts ->> 'host_type'::text)), modified_on, org_id) WHERE ((system_profile_facts -> 'operating_system'::text) IS NOT NULL);
+
+
+--
+-- Name: idxaccstaleorgid; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idxaccstaleorgid ON hbi.staleness USING btree (org_id);
+
+
+--
+-- Name: idxansible; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idxansible ON hbi.hosts USING btree (((system_profile_facts ->> 'ansible'::text)));
+
+
+--
+-- Name: idxbootc_status; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idxbootc_status ON hbi.hosts USING btree (org_id) WHERE ((((system_profile_facts -> 'bootc_status'::text) -> 'booted'::text) ->> 'image_digest'::text) IS NOT NULL);
+
+
+--
+-- Name: idxgincanonicalfacts; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idxgincanonicalfacts ON hbi.hosts USING gin (canonical_facts jsonb_path_ops);
+
+
+--
+-- Name: idxgrouporgid; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idxgrouporgid ON hbi.groups USING btree (org_id);
+
+
+--
+-- Name: idxgroupshosts; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE UNIQUE INDEX idxgroupshosts ON hbi.hosts_groups USING btree (group_id, host_id);
+
+
+--
+-- Name: idxhostsgroups; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE UNIQUE INDEX idxhostsgroups ON hbi.hosts_groups USING btree (host_id, group_id);
+
+
+--
+-- Name: idxinsightsid; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idxinsightsid ON hbi.hosts USING btree (((canonical_facts ->> 'insights_id'::text)));
+
+
+--
+-- Name: idxmssql; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idxmssql ON hbi.hosts USING btree (((system_profile_facts ->> 'mssql'::text)));
+
+
+--
+-- Name: idxorgid; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idxorgid ON hbi.hosts USING btree (org_id);
+
+
+--
+-- Name: idxorgidungrouped; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idxorgidungrouped ON hbi.groups USING btree (org_id, ungrouped);
+
+
+--
+-- Name: idxsap_system; Type: INDEX; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE INDEX idxsap_system ON hbi.hosts USING btree ((((system_profile_facts ->> 'sap_system'::text))::boolean));
+
+
+--
+-- Name: hosts_groups_p0_org_id_group_id_host_id_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_groups_reverse ATTACH PARTITION hbi.hosts_groups_p0_org_id_group_id_host_id_idx;
+
+
+--
+-- Name: hosts_groups_p0_org_id_host_id_group_id_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_groups_forward ATTACH PARTITION hbi.hosts_groups_p0_org_id_host_id_group_id_idx;
+
+
+--
+-- Name: hosts_groups_p0_pkey; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.hosts_groups_new_pkey ATTACH PARTITION hbi.hosts_groups_p0_pkey;
+
+
+--
+-- Name: hosts_groups_p1_org_id_group_id_host_id_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_groups_reverse ATTACH PARTITION hbi.hosts_groups_p1_org_id_group_id_host_id_idx;
+
+
+--
+-- Name: hosts_groups_p1_org_id_host_id_group_id_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_groups_forward ATTACH PARTITION hbi.hosts_groups_p1_org_id_host_id_group_id_idx;
+
+
+--
+-- Name: hosts_groups_p1_pkey; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.hosts_groups_new_pkey ATTACH PARTITION hbi.hosts_groups_p1_pkey;
+
+
+--
+-- Name: hosts_p0_bool_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_sap_system ATTACH PARTITION hbi.hosts_p0_bool_idx;
+
+
+--
+-- Name: hosts_p0_canonical_facts_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_canonical_facts_gin ATTACH PARTITION hbi.hosts_p0_canonical_facts_idx;
+
+
+--
+-- Name: hosts_p0_expr_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_host_type ATTACH PARTITION hbi.hosts_p0_expr_idx;
+
+
+--
+-- Name: hosts_p0_expr_idx1; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_cf_insights_id ATTACH PARTITION hbi.hosts_p0_expr_idx1;
+
+
+--
+-- Name: hosts_p0_expr_idx2; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_cf_subscription_manager_id ATTACH PARTITION hbi.hosts_p0_expr_idx2;
+
+
+--
+-- Name: hosts_p0_expr_idx3; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_mssql ATTACH PARTITION hbi.hosts_p0_expr_idx3;
+
+
+--
+-- Name: hosts_p0_expr_idx4; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_ansible ATTACH PARTITION hbi.hosts_p0_expr_idx4;
+
+
+--
+-- Name: hosts_p0_expr_int4_int41_expr1_modified_on_org_id_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_operating_system_multi ATTACH PARTITION hbi.hosts_p0_expr_int4_int41_expr1_modified_on_org_id_idx;
+
+
+--
+-- Name: hosts_p0_groups_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_groups_gin ATTACH PARTITION hbi.hosts_p0_groups_idx;
+
+
+--
+-- Name: hosts_p0_insights_id_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_insights_id ATTACH PARTITION hbi.hosts_p0_insights_id_idx;
+
+
+--
+-- Name: hosts_p0_modified_on_id_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_modified_on_id ATTACH PARTITION hbi.hosts_p0_modified_on_id_idx;
+
+
+--
+-- Name: hosts_p0_org_id_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_bootc_status ATTACH PARTITION hbi.hosts_p0_org_id_idx;
+
+
+--
+-- Name: hosts_p0_org_id_modified_on_expr_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_host_type_modified_on_org_id ATTACH PARTITION hbi.hosts_p0_org_id_modified_on_expr_idx;
+
+
+--
+-- Name: hosts_p0_pkey; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.hosts_new_pkey ATTACH PARTITION hbi.hosts_p0_pkey;
+
+
+--
+-- Name: hosts_p0_subscription_manager_id_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_subscription_manager_id ATTACH PARTITION hbi.hosts_p0_subscription_manager_id_idx;
+
+
+--
+-- Name: hosts_p1_bool_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_sap_system ATTACH PARTITION hbi.hosts_p1_bool_idx;
+
+
+--
+-- Name: hosts_p1_canonical_facts_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_canonical_facts_gin ATTACH PARTITION hbi.hosts_p1_canonical_facts_idx;
+
+
+--
+-- Name: hosts_p1_expr_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_host_type ATTACH PARTITION hbi.hosts_p1_expr_idx;
+
+
+--
+-- Name: hosts_p1_expr_idx1; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_cf_insights_id ATTACH PARTITION hbi.hosts_p1_expr_idx1;
+
+
+--
+-- Name: hosts_p1_expr_idx2; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_cf_subscription_manager_id ATTACH PARTITION hbi.hosts_p1_expr_idx2;
+
+
+--
+-- Name: hosts_p1_expr_idx3; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_mssql ATTACH PARTITION hbi.hosts_p1_expr_idx3;
+
+
+--
+-- Name: hosts_p1_expr_idx4; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_ansible ATTACH PARTITION hbi.hosts_p1_expr_idx4;
+
+
+--
+-- Name: hosts_p1_expr_int4_int41_expr1_modified_on_org_id_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_operating_system_multi ATTACH PARTITION hbi.hosts_p1_expr_int4_int41_expr1_modified_on_org_id_idx;
+
+
+--
+-- Name: hosts_p1_groups_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_groups_gin ATTACH PARTITION hbi.hosts_p1_groups_idx;
+
+
+--
+-- Name: hosts_p1_insights_id_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_insights_id ATTACH PARTITION hbi.hosts_p1_insights_id_idx;
+
+
+--
+-- Name: hosts_p1_modified_on_id_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_modified_on_id ATTACH PARTITION hbi.hosts_p1_modified_on_id_idx;
+
+
+--
+-- Name: hosts_p1_org_id_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_bootc_status ATTACH PARTITION hbi.hosts_p1_org_id_idx;
+
+
+--
+-- Name: hosts_p1_org_id_modified_on_expr_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_host_type_modified_on_org_id ATTACH PARTITION hbi.hosts_p1_org_id_modified_on_expr_idx;
+
+
+--
+-- Name: hosts_p1_pkey; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.hosts_new_pkey ATTACH PARTITION hbi.hosts_p1_pkey;
+
+
+--
+-- Name: hosts_p1_subscription_manager_id_idx; Type: INDEX ATTACH; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER INDEX hbi.idx_hosts_subscription_manager_id ATTACH PARTITION hbi.hosts_p1_subscription_manager_id_idx;
+
+
+--
+-- Name: hosts_groups_new fk_hosts_groups_on_groups; Type: FK CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE hbi.hosts_groups_new
+    ADD CONSTRAINT fk_hosts_groups_on_groups FOREIGN KEY (group_id) REFERENCES hbi.groups(id);
+
+
+--
+-- Name: hosts_groups_new fk_hosts_groups_on_hosts; Type: FK CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE hbi.hosts_groups_new
+    ADD CONSTRAINT fk_hosts_groups_on_hosts FOREIGN KEY (org_id, host_id) REFERENCES hbi.hosts_new(org_id, id) ON DELETE CASCADE;
+
+
+--
+-- Name: hosts_groups hosts_groups_group_id_fkey; Type: FK CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hosts_groups
+    ADD CONSTRAINT hosts_groups_group_id_fkey FOREIGN KEY (group_id) REFERENCES hbi.groups(id);
+
+
+--
+-- Name: hosts_groups hosts_groups_host_id_fkey; Type: FK CONSTRAINT; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER TABLE ONLY hbi.hosts_groups
+    ADD CONSTRAINT hosts_groups_host_id_fkey FOREIGN KEY (host_id) REFERENCES hbi.hosts(id);
+
+
+--
+-- Name: hbi_hosts_pub_v1_0_1; Type: PUBLICATION; Schema: -; Owner: VBzEIpnveJmm3TXi
+--
+
+CREATE PUBLICATION hbi_hosts_pub_v1_0_1 WITH (publish = 'insert, update, delete, truncate');
+
+
+ALTER PUBLICATION hbi_hosts_pub_v1_0_1 OWNER TO "VBzEIpnveJmm3TXi";
+
+--
+-- Name: hbi_hosts_pub_v1_0_1 hosts; Type: PUBLICATION TABLE; Schema: hbi; Owner: VBzEIpnveJmm3TXi
+--
+
+ALTER PUBLICATION hbi_hosts_pub_v1_0_1 ADD TABLE ONLY hbi.hosts (id, account, display_name, created_on, modified_on, facts, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id, groups, tags_alt, last_check_in, stale_warning_timestamp, deletion_timestamp);
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/development/configs/postgresql.conf
+++ b/development/configs/postgresql.conf
@@ -1,0 +1,7 @@
+max_connections = 100
+listen_addresses = '*'
+shared_buffers = 128MB
+work_mem = 4MB
+wal_level = logical
+log_destination = 'stderr'
+track_commit_timestamp = on

--- a/development/docker-compose.yaml
+++ b/development/docker-compose.yaml
@@ -1,0 +1,81 @@
+services:
+  full-setup:
+    image: bash:3.1-alpine3.21
+    command: ["echo", "starting full-setup"]
+    depends_on:
+    - inventory-consumer
+    - hbidatabase
+    - kafka-setup
+    - kic-connect
+    networks:
+      - kessel
+    restart: on-failure
+
+### Individual services
+  inventory-consumer:
+    environment:
+      INVENTORY_CONSUMER_CONFIG: /inventory-consumer-config.yaml
+    build:
+      context: ../
+      dockerfile: Dockerfile
+      args:
+        VERSION: dev
+    volumes:
+      - ./configs/${CONFIG}.yaml:/inventory-consumer-config.yaml:ro,z
+    command: ["start"]
+    restart: "always"
+    networks:
+      - kessel
+
+  hbidatabase:
+    image: "postgres"
+    command: ["docker-entrypoint.sh", "-p", "5432", "-c", "config_file=/etc/postgresql/postgresql.conf"]
+    hostname: hbidatabase
+    expose:
+      - "5432"
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./configs/postgresql.conf:/etc/postgresql/postgresql.conf:ro,z
+    environment:
+      - "POSTGRES_PASSWORD=supersecurewow"
+      - "POSTGRES_DB=host-inventory"
+      - "PGPORT=5432"
+    networks:
+      - kessel
+
+  kafka-setup:
+    image: quay.io/strimzi/kafka:latest-kafka-3.8.0
+    entrypoint: [ '/bin/sh', '-c' ]
+    command: |
+      "
+      echo -e 'Creating kafka topics'
+      bin/kafka-topics.sh --bootstrap-server kafka:9093 --create --if-not-exists --topic host-inventory.hbi.hosts --replication-factor 1 --partitions 1
+      bin/kafka-topics.sh --bootstrap-server kafka:9093 --create --if-not-exists --topic outbox.event.hbi.hosts --replication-factor 1 --partitions 1
+      "
+    networks:
+      - kessel
+
+  kic-connect:
+    ports:
+      - 8084:8083
+    environment:
+      - GROUP_ID=2
+      - CONFIG_STORAGE_TOPIC=kessel_kafka_connect_configs
+      - OFFSET_STORAGE_TOPIC=kessel_kafka_connect_offsets
+      - STATUS_STORAGE_TOPIC=kessel_kafka_connect_statuses
+      - BOOTSTRAP_SERVERS=kafka:9093
+    depends_on:
+      - kafka-setup
+    image: quay.io/debezium/connect:2.5
+    restart: "always"
+    networks:
+      - kessel
+
+volumes:
+  grafana-storage: {}
+
+networks:
+  kessel:
+    name: kessel
+    external: true

--- a/development/docs/local-hbi-migration-testing.md
+++ b/development/docs/local-hbi-migration-testing.md
@@ -1,0 +1,19 @@
+# Local HBI Migration Testing using Hosts Table
+
+
+### Steps:
+
+1. Spin up everything via podman compose (See [Using Podman Compose](../../README.md#using-podman-compose)
+2. Configure the HBI database: `make setup-hbi-db`
+3. Generate SQL import files with host records using the [db-host-generator.sh](../../scripts/db-host-generator.sh) script
+4. Import host records: `PGPASSWORD=supersecurewow psql -h localhost -p 5432 -d host-inventory -U postgres -f path/to/import-sql-files
+5. Setup the Connector: `make setup-migration-connector`
+
+At this point the connecter is started, and Debezium will begin the snapshot of the hosts table and capture all existing records.
+
+
+### Clean Up:
+
+1. Shut down the KIC setup: `make inventory-consumer-down`
+2. Shut down Kessel Inventory: `cd path/to/inventory-api && make inventory-down`
+3. Shut down Kessel Relations: `cd path/to/relations-api && make relations-api-down`

--- a/scripts/check_docker_podman.sh
+++ b/scripts/check_docker_podman.sh
@@ -1,0 +1,22 @@
+# Function to check if a command is available
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Check if Docker is installed
+if command_exists docker; then
+  echo "Docker is installed. Using Docker."
+  export DOCKER=docker
+else
+  echo "Docker not found. Checking for Podman."
+
+  # Check if Podman is installed
+  if command_exists podman; then
+    echo "Podman is installed. Using Podman."
+    export DOCKER=podman
+  else
+    echo "Podman not found. Please install either Docker or Podman to proceed."
+    exit 1
+  fi
+fi
+

--- a/scripts/db-host-generator.sh
+++ b/scripts/db-host-generator.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# prints a handy help menu with usage
+help_me() {
+    echo "USAGE: db-host-generator.sh {-n <NUM_HOSTS>} [-c <NUM_FILES>|-h]"
+    echo "db-host-generator: creates unique fake host records to add to HBI database for migration testing"
+    echo "The records are created in batches of 1000 records and dumped to a file for importing"
+    echo ""
+    echo "REQUIRED ARGUMENTS:"
+    echo "  -n NUM_HOSTS: The number of hosts to create in 1000's (ie -n 1 creates 1000 hosts)"
+    echo ""
+    echo "OPTIONS:"
+    echo "  -h Prints usage information"
+    echo "  -c NUM_HOSTS: If provided, creates X number of files with -n number hosts*1000 per file"
+
+    echo ""
+    echo "EXAMPLE:"
+    echo "Create 5000 hosts in a single import file"
+    echo "  load-generator.sh -n 5"
+    echo ""
+    echo "Create 5 files with 5000 hosts in each file (total of 25,000 hosts)"
+    echo "  load-generator.sh -n 5 -c 5"
+    exit 0
+}
+
+generate_import_file() {
+    FILE_NAME=$1
+    for ((i = 1  ; i <= ${NUM_BATCHES} ; i++)); do
+        # Generate a unique ID and hostname
+        ID=$(printf "'%s'" $(uuidgen))
+        HOST=$(printf "'%s'" $(echo ${ID:1:7}.foo.redhat.com))
+        CANONICAL_FACTS="'{\"insights_id\": \"62a6917d-bff6-4b77-a185-d570472b0699\", \"provider_id\": \"26be74db-d31e-4d94-bde1-4a0914901d98\", \"provider_type\": \"ibm\"}'"
+
+        if [[ $(( $i%1000 )) -eq 0 ]]; then
+            NEW_VALUE="($ID, $HOST, '2025-07-10 15:03:41.855142+00', '2025-07-10 15:03:41.855145+00', $CANONICAL_FACTS::jsonb, '2025-07-11 20:03:41.75047+00', 'rhsm-conduit', '321', '[]', '2025-07-10 15:03:41.75047+00', '2025-07-17 15:03:41.75047+00', '2025-07-24 15:03:41.75047+00');"
+            VALUES+=($NEW_VALUE)
+            echo "INSERT INTO hbi.hosts (id, display_name, created_on, modified_on, canonical_facts, stale_timestamp, reporter, org_id, groups, last_check_in, stale_warning_timestamp, deletion_timestamp) VALUES ${VALUES[*]}" >> $FILE_NAME
+            echo "" >> $FILE_NAME
+            unset VALUES
+        else
+            NEW_VALUE="($ID, $HOST, '2025-07-10 15:03:41.855142+00', '2025-07-10 15:03:41.855145+00', $CANONICAL_FACTS::jsonb, '2025-07-11 20:03:41.75047+00', 'rhsm-conduit', '321', '[]', '2025-07-10 15:03:41.75047+00', '2025-07-17 15:03:41.75047+00', '2025-07-24 15:03:41.75047+00'),"
+            VALUES+=($NEW_VALUE)
+        fi
+    done
+}
+
+while getopts "n:c:h" flag; do
+    case "${flag}" in
+        n) NUM_HOSTS=${OPTARG};;
+        c) NUM_FILES=${OPTARG};;
+        h) help_me;;
+    esac
+done
+
+if [[  -z "${NUM_HOSTS}" ]]; then
+  echo "Error: required arguments not provided"
+  help_me
+fi
+
+declare -a VALUES
+NUM_BATCHES=$(( $NUM_HOSTS*1000 ))
+
+rm import-*.sql
+
+for ((count = 1  ; count <= ${NUM_FILES} ; count++)); do
+    generate_import_file import-${count}.sql
+done

--- a/scripts/start-inventory-consumer.sh
+++ b/scripts/start-inventory-consumer.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export CONFIG=$1
+export SETUP=${CONFIG}
+
+set -e
+# Function to check if a command is available
+source ./scripts/check_docker_podman.sh
+NETWORK_CHECK=$(${DOCKER} network ls --filter name=kessel --format json)
+if [[ -z "${NETWORK_CHECK}" || "${NETWORK_CHECK}" == "[]" ]]; then ${DOCKER} network create kessel; fi
+${DOCKER} compose -f development/docker-compose.yaml up --build -d ${SETUP}

--- a/scripts/stop-inventory-consumer.sh
+++ b/scripts/stop-inventory-consumer.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+export CONFIG=""
+
+# Function to check if a command is available
+source ./scripts/check_docker_podman.sh
+${DOCKER} compose -f development/docker-compose.yaml down


### PR DESCRIPTION
* Duplicates a lot of the docker compose setup from inventory API setup but for Inventory Consumer including scripts
  * includes separeate Connect and includes HBI database for testing
* adds connector for testing purposes
* updates README for using podman compose (requires infra provided by inventory API)
* adds db-host-generator script for creating SQL script files for importing HBI hosts
* adds info on testing HBI migration locally