### PR TITLE
updates to allow for ad-hoc snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,7 @@ setup-hbi-db:
 .PHONY: setup-migration-connector
 setup-migration-connector:
 	curl -d @development/configs/debezium-connector.json -H 'Content-Type: application/json' -X POST http://localhost:8084/connectors
+
+.PHONY: setup-migration-connector-no-snapshot
+setup-migration-connector-no-snapshot:
+	curl -d @development/configs/debezium-connector-no-snapshot.json -H 'Content-Type: application/json' -X POST http://localhost:8084/connectors

--- a/development/configs/debezium-connector-no-snapshot.json
+++ b/development/configs/debezium-connector-no-snapshot.json
@@ -1,0 +1,35 @@
+{
+  "name": "hbi-migration-connector",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "slot.name": "debezium_hosts",
+    "signal.enabled.channels": "source,kafka",
+    "signal.kafka.topic": "host-inventory.signal",
+    "signal.kafka.bootstrap.servers": "kafka:9093",
+    "signal.data.collection": "hbi.signal",
+    "snapshot.mode": "no_data",
+    "database.server.name": "host-inventory-db",
+    "database.dbname": "host-inventory",
+    "database.hostname": "hbidatabase",
+    "database.port": "5432",
+    "database.user": "postgres",
+    "database.password": "supersecurewow",
+    "topic.prefix": "host-inventory",
+    "table.include.list": "hbi.hosts",
+    "plugin.name": "pgoutput",
+    "transforms": "unwrap,addMetadata,addHeaders,fieldFilter",
+    "transforms.unwrap.type": "io.debezium.transforms.ExtractNewRecordState",
+    "transforms.unwrap.drop.tombstones": "false",
+    "transforms.unwrap.delete.handling.mode": "rewrite",
+    "transforms.addMetadata.type": "org.apache.kafka.connect.transforms.InsertField$Value",
+    "transforms.addMetadata.static.field": "source_system",
+    "transforms.addMetadata.static.value": "host-inventory-db",
+    "transforms.addHeaders.type": "org.apache.kafka.connect.transforms.InsertHeader",
+    "transforms.addHeaders.header": "operation",
+    "transforms.addHeaders.value.literal": "migration",
+    "transforms.fieldFilter.type": "org.apache.kafka.connect.transforms.ReplaceField$Value",
+    "transforms.fieldFilter.exclude": "deletion_timestamp,facts,last_check_in,modified_on,per_reporter_staleness,stale_timestamp,stale_warning_timestamp,tags,tags_alt",
+    "transforms.fieldFilter.renames": "display_name:hostname,org_id:organization_id"
+  }
+}
+

--- a/development/configs/hbi-full-setup.sql
+++ b/development/configs/hbi-full-setup.sql
@@ -1283,6 +1283,7 @@ ALTER PUBLICATION hbi_hosts_pub_v1_0_1 OWNER TO "VBzEIpnveJmm3TXi";
 
 ALTER PUBLICATION hbi_hosts_pub_v1_0_1 ADD TABLE ONLY hbi.hosts (id, account, display_name, created_on, modified_on, facts, canonical_facts, system_profile_facts, ansible_host, stale_timestamp, reporter, per_reporter_staleness, org_id, groups, tags_alt, last_check_in, stale_warning_timestamp, deletion_timestamp);
 
+CREATE TABLE hbi.signal (id VARCHAR(255) PRIMARY KEY, type VARCHAR(255) NOT NULL, data VARCHAR(255) NULL);
 
 --
 -- PostgreSQL database dump complete

--- a/development/docker-compose.yaml
+++ b/development/docker-compose.yaml
@@ -52,6 +52,7 @@ services:
       echo -e 'Creating kafka topics'
       bin/kafka-topics.sh --bootstrap-server kafka:9093 --create --if-not-exists --topic host-inventory.hbi.hosts --replication-factor 1 --partitions 1
       bin/kafka-topics.sh --bootstrap-server kafka:9093 --create --if-not-exists --topic outbox.event.hbi.hosts --replication-factor 1 --partitions 1
+      bin/kafka-topics.sh --bootstrap-server kafka:9093 --create --if-not-exists --topic host-inventory.signal --replication-factor 1 --partitions 1
       "
     networks:
       - kessel
@@ -67,7 +68,7 @@ services:
       - BOOTSTRAP_SERVERS=kafka:9093
     depends_on:
       - kafka-setup
-    image: quay.io/debezium/connect:2.5
+    image: quay.io/debezium/connect:2.7
     restart: "always"
     networks:
       - kessel

--- a/development/docs/local-hbi-migration-testing.md
+++ b/development/docs/local-hbi-migration-testing.md
@@ -17,3 +17,20 @@ At this point the connecter is started, and Debezium will begin the snapshot of 
 1. Shut down the KIC setup: `make inventory-consumer-down`
 2. Shut down Kessel Inventory: `cd path/to/inventory-api && make inventory-down`
 3. Shut down Kessel Relations: `cd path/to/relations-api && make relations-api-down`
+
+
+### Incremental Snapshots
+
+To test using incremental snapshots:
+
+1. Spin up everything via podman compose (See [Using Podman Compose](../../README.md#using-podman-compose)
+2. Configure the HBI database: `make setup-hbi-db`
+3. Generate SQL import files with host records using the [db-host-generator.sh](../../scripts/db-host-generator.sh) script
+4. Import host records: `PGPASSWORD=supersecurewow psql -h localhost -p 5432 -d host-inventory -U postgres -f path/to/import-sql-files
+5. Setup the `no-snapshot` Connector: `make setup-migration-connector-no-snapshot`
+
+When the connector is started, the intial snapshot will not run due to `snapshot.mode` being set to `"no_data"`.To trigger a snapshot, you must produce a signal to the signal topic which will trigger the snapshot. Note, the signal table is required even when using the topic as it leverages the table as part of its snapshot process
+
+To trigger the snapshot (requires [kcat](https://github.com/edenhill/kcat?tab=readme-ov-file#install)):
+
+`echo 'host-inventory|{"type":"execute-snapshot","data":{"data-collections":["hbi.hosts"],"type":"INCREMENTAL"}}' | kcat -P -b localhost:9092 -t host-inventory.signal -K "|"`


### PR DESCRIPTION
* adds signal table required for snapshots to DB setup script
* adds signal topic needed for snapshots
* adds a second connect and make target for disabling the initial snapshot and allowing for ad hoc snapshots
* adds make target for creating no-snapshot connector
* updates doc to add steps to trigger snapshot