### PR TITLE
adds new topics for hbi host partitioning

### DIFF
--- a/deploy/kessel-inventory-consumer-ephem.yaml
+++ b/deploy/kessel-inventory-consumer-ephem.yaml
@@ -13,6 +13,8 @@ objects:
           topics:
           - outbox.event.hbi.hosts
           - host-inventory.hbi.hosts
+          - host-inventory.hbi.hosts_p0
+          - host-inventory.hbi.hosts_p1
           retry-options:
             consumer-max-retries: 3
             operation-max-retries: 4
@@ -36,10 +38,16 @@ objects:
       kafkaTopics:
       - topicName: outbox.event.hbi.hosts
         partitions: ${{PARTITIONS}}
-        replicas: 3
+        replicas: 1
       - topicName: host-inventory.hbi.hosts
         partitions: ${{PARTITIONS}}
-        replicas: 3
+        replicas: 1
+      - topicName: host-inventory.hbi.hosts_p0
+        partitions: ${{PARTITIONS}}
+        replicas: 1
+      - topicName: host-inventory.hbi.hosts_p1
+        partitions: ${{PARTITIONS}}
+        replicas: 1
       optionalDependencies:
         - kessel-inventory
         - kessel-relations


### PR DESCRIPTION
Updates the topics to watch for HBI testing as they have moved to partitioning the hosts table. This requires we watch the partition tables as well, plus ensure the topics exist for the consumer to connect to them. Also drops replicas for partitions to one since there is only one kafka pod

https://github.com/RedHatInsights/insights-host-inventory/pull/2731
https://github.com/RedHatInsights/insights-host-inventory/pull/2766