### PR TITLE
adds consumer enabled option

### DIFF
--- a/.inventory-consumer.yaml
+++ b/.inventory-consumer.yaml
@@ -1,8 +1,8 @@
 consumer:
+  enabled: true
   bootstrap-servers: localhost:9092
   topics:
-  - hbi.replication.events
-  - host-inventory.hbi.hosts
+  - outbox.event.hbi.hosts
   retry-options:
     consumer-max-retries: 3
     operation-max-retries: 4

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,7 @@ var (
 	cfgFile string
 
 	logger *log.Helper
-	icrg   consumer.InventoryConsumer
+	kic    consumer.InventoryConsumer
 	err    error
 	errs   []error
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -62,14 +62,18 @@ subscribed to the provided topic`,
 			go metricscollector.ServeMetrics()
 
 			srvErrs := make(chan error)
-			go func() {
-				srvErrs <- icrg.Run(consumerOptions, consumerConfig, client, logHelper)
-			}()
+			if consumerConfig.Enabled {
+				go func() {
+					srvErrs <- kic.Run(consumerOptions, consumerConfig, client, logHelper)
+				}()
+			} else {
+				log.Info("Consumer disabled -- running in Standby mode")
+			}
 			select {
 			case <-quit:
-				shutdown(&icrg, logHelper, fmt.Errorf("received signal \"quit\", shutting down"))
+				shutdown(&kic, logHelper, fmt.Errorf("received signal \"quit\", shutting down"))
 			case err := <-srvErrs:
-				shutdown(&icrg, logHelper, err)
+				shutdown(&kic, logHelper, err)
 			}
 			return nil
 

--- a/consumer/options.go
+++ b/consumer/options.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Options struct {
+	Enabled            bool           `mapstructure:"enabled"`
 	BootstrapServers   []string       `mapstructure:"bootstrap-servers"`
 	ConsumerGroupID    string         `mapstructure:"consumer-group-id"`
 	Topics             []string       `mapstructure:"topics"`
@@ -25,6 +26,7 @@ type Options struct {
 
 func NewOptions() *Options {
 	return &Options{
+		Enabled:            true,
 		ConsumerGroupID:    "kic",
 		SessionTimeout:     "45000",
 		HeartbeatInterval:  "3000",
@@ -42,6 +44,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 	if prefix != "" {
 		prefix = prefix + "."
 	}
+	fs.BoolVar(&o.Enabled, prefix+"enabled", o.Enabled, "enables/disables consumer (default: true)")
 	fs.StringSliceVar(&o.BootstrapServers, prefix+"bootstrap-servers", o.BootstrapServers, "sets the bootstrap server address and port for Kafka")
 	fs.StringVar(&o.ConsumerGroupID, prefix+"consumer-group-id", o.ConsumerGroupID, "sets the Kafka consumer group name (default: inventory-consumer)")
 	fs.StringArrayVar(&o.Topics, prefix+"topics", o.Topics, "Kafka topic to monitor for events")
@@ -60,11 +63,11 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 func (o *Options) Validate() []error {
 	var errs []error
 
-	if len(o.BootstrapServers) == 0 {
+	if len(o.BootstrapServers) == 0 && o.Enabled {
 		errs = append(errs, fmt.Errorf("bootstrap servers can not be empty"))
 	}
 
-	if len(o.Topics) == 0 {
+	if len(o.Topics) == 0 && o.Enabled {
 		errs = append(errs, fmt.Errorf("topic value can not be empty"))
 	}
 	return errs

--- a/consumer/options_test.go
+++ b/consumer/options_test.go
@@ -17,6 +17,7 @@ func TestNewOptions(t *testing.T) {
 	}{
 		options: NewOptions(),
 		expectedOptions: &Options{
+			Enabled:            true,
 			ConsumerGroupID:    "kic",
 			SessionTimeout:     "45000",
 			HeartbeatInterval:  "3000",
@@ -67,6 +68,7 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "bootstrap servers is empty and topic is set",
 			options: &Options{
+				Enabled:          true,
 				BootstrapServers: []string{},
 				Topics:           []string{"test-topic"},
 			},
@@ -75,6 +77,7 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "bootstrap servers is empty and topic is empty",
 			options: &Options{
+				Enabled:          true,
 				BootstrapServers: []string{},
 				Topics:           []string{},
 			},
@@ -83,12 +86,22 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "bootstrap servers is set and topic is empty",
 			options: &Options{
+				Enabled: true,
 				BootstrapServers: []string{
 					"test-server:9092",
 				},
 				Topics: []string{},
 			},
 			expectError: true,
+		},
+		{
+			name: "bootstrap servers and/or topic can be empty if consumer disabled",
+			options: &Options{
+				Enabled:          false,
+				BootstrapServers: []string{},
+				Topics:           []string{},
+			},
+			expectError: false,
 		},
 	}
 

--- a/internal/client/options.go
+++ b/internal/client/options.go
@@ -40,7 +40,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 func (o *Options) Validate() []error {
 	var errs []error
 
-	if len(o.InventoryURL) == 0 {
+	if len(o.InventoryURL) == 0 && o.Enabled {
 		errs = append(errs, fmt.Errorf("kessel url may not be empty"))
 	}
 


### PR DESCRIPTION
* adds consumer enable/disable option to allow for deploying in new env where topics/kafka may not be setup yet
* updates consumer option validation to allow for empty values when not enabled
  * similar change also added for inventory client as it was missing
*  test update for new option

Example logs when its disabled
```shell
$ ./bin/inventory-consumer start
INFO msg=Using config file: /home/anatale/go/src/github.com/tonytheleg/inventory-consumer/.inventory-consumer.yaml
Log Level is set to: info
Log Level is set to: info
INFO ts=2025-07-28T11:25:02-04:00 caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=client msg=Setting up Inventory API client
INFO ts=2025-07-28T11:25:02-04:00 caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=client msg=ClientProvider enabled: false
INFO msg=starting metrics server on port :9000
INFO msg=Consumer disabled -- running in Standby mode
```