### PR TITLE
Remove old common definition, remove orgID for hosts

### DIFF
--- a/consumer/transforms/hosts.go
+++ b/consumer/transforms/hosts.go
@@ -30,9 +30,6 @@ func TransformHostToReportResourceRequest(msg []byte) (*kesselv2.ReportResourceR
 				"console_href":      types.HostConsoleHref,
 				"reporter_version":  types.HostReporterVersion,
 			},
-			"common": map[string]interface{}{
-				"workspace_id": hostMsg.Payload.Groups[0].ID,
-			},
 			"reporter": map[string]interface{}{
 				"satellite_id":          hostMsg.Payload.SatelliteID,
 				"sub_manager_id":        hostMsg.Payload.SubscriptionManagerID,
@@ -40,7 +37,7 @@ func TransformHostToReportResourceRequest(msg []byte) (*kesselv2.ReportResourceR
 				"ansible_host":          hostMsg.Payload.AnsibleHost,
 			},
 			"common_resource_data": map[string]interface{}{
-				"workspace_id": hostMsg.Payload.OrganizationID,
+				"workspace_id": hostMsg.Payload.Groups[0].ID,
 			},
 		},
 	}

--- a/consumer/types/host_types.go
+++ b/consumer/types/host_types.go
@@ -23,7 +23,6 @@ type HostMessage struct {
 type HostPayload struct {
 	ID                    string     `json:"id"`
 	AnsibleHost           string     `json:"ansible_host"`
-	OrganizationID        string     `json:"organization_id"`
 	InsightsID            string     `json:"insights_id"`
 	SubscriptionManagerID string     `json:"subscription_manager_id"`
 	SatelliteID           string     `json:"satellite_id"`


### PR DESCRIPTION
- Removes org ID from host payload
- Removes duplicate `common` attribute