### PR TITLE
Improve testing

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -358,7 +358,7 @@ func CheckIfCommit(partition kafka.TopicPartition) bool {
 	return partition.Offset%commitModulo == 0
 }
 
-// FormatOffsets converts a slice of partitions with offset data into a more readable shorthand-coded string to capture what partitions and offsets were comitted
+// FormatOffsets converts a slice of partitions with offset data into a more readable shorthand-coded string to capture what partitions and offsets were committed
 func FormatOffsets(offsets []kafka.TopicPartition) string {
 	var committedOffsets []string
 	for _, partition := range offsets {

--- a/consumer/parsers_test.go
+++ b/consumer/parsers_test.go
@@ -1,0 +1,125 @@
+package consumer
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	kesselv2 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseHeaders(t *testing.T) {
+	tests := []struct {
+		name              string
+		expectedOperation string
+		expectedTxid      string
+		msg               *kafka.Message
+		expectErr         bool
+	}{
+		{
+			name:              "Create Operation",
+			expectedOperation: OperationTypeCreated,
+			expectedTxid:      "123456",
+			msg: &kafka.Message{
+				Headers: []kafka.Header{
+					{Key: "operation", Value: []byte(OperationTypeCreated)},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name:              "Update Operation",
+			expectedOperation: OperationTypeUpdated,
+			expectedTxid:      "123456",
+			msg: &kafka.Message{
+				Headers: []kafka.Header{
+					{Key: "operation", Value: []byte(OperationTypeUpdated)},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name:              "Delete Operation",
+			expectedOperation: OperationTypeDeleted,
+			expectedTxid:      "",
+			msg: &kafka.Message{
+				Headers: []kafka.Header{
+					{Key: "operation", Value: []byte(OperationTypeDeleted)},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name:              "Missing Operation Header",
+			expectedOperation: "",
+			expectedTxid:      "123456",
+			msg: &kafka.Message{
+				Headers: []kafka.Header{},
+			},
+			expectErr: true,
+		},
+		{
+			name:              "Missing Operation Value",
+			expectedOperation: "",
+			expectedTxid:      "123456",
+			msg: &kafka.Message{
+				Headers: []kafka.Header{
+					{Key: "operation", Value: []byte{}},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:              "Extra Headers",
+			expectedOperation: OperationTypeCreated,
+			expectedTxid:      "123456",
+			msg: &kafka.Message{
+				Headers: []kafka.Header{
+					{Key: "operation", Value: []byte(OperationTypeCreated)},
+					{Key: "unused-header", Value: []byte("unused-header-data")},
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parsedHeaders, err := ParseHeaders(test.msg, requiredHeaders)
+			if test.expectErr {
+				assert.NotNil(t, err)
+				assert.Nil(t, parsedHeaders)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, parsedHeaders["operation"], test.expectedOperation)
+				assert.LessOrEqual(t, len(parsedHeaders), 2)
+			}
+		})
+	}
+}
+
+func TestParseCreateOrUpdateMessage(t *testing.T) {
+	expected := makeReportResourceRequest()
+	var req kesselv2.ReportResourceRequest
+	err := ParseCreateOrUpdateMessage([]byte(testCreateOrUpdateMessage), &req)
+	assert.Nil(t, err)
+	assert.Equal(t, expected.InventoryId, req.InventoryId)
+	assert.Equal(t, expected.Type, req.Type)
+	assert.Equal(t, expected.ReporterType, req.ReporterType)
+	assert.Equal(t, expected.ReporterInstanceId, req.ReporterInstanceId)
+	assert.True(t, reflect.DeepEqual(expected.Representations.Metadata, req.Representations.Metadata))
+	assert.True(t, reflect.DeepEqual(expected.Representations.Common.AsMap(), req.Representations.Common.AsMap()))
+	assert.True(t, reflect.DeepEqual(expected.Representations.Reporter.AsMap(), req.Representations.Reporter.AsMap()))
+}
+
+func TestParseDeleteMessage(t *testing.T) {
+	expected := makeDeleteResourceRequest()
+	var req kesselv2.DeleteResourceRequest
+	err := ParseDeleteMessage([]byte(testDeleteMessage), &req)
+	assert.Nil(t, err)
+	assert.Equal(t, expected.Reference.ResourceId, req.Reference.ResourceId)
+	assert.Equal(t, expected.Reference.ResourceType, req.Reference.ResourceType)
+	assert.True(t, reflect.DeepEqual(expected.Reference.Reporter, req.Reference.Reporter))
+
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,277 @@
+package kessel
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-kratos/kratos/v2/log"
+	kesselv2 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+	"github.com/project-kessel/inventory-consumer/internal/common"
+	"github.com/project-kessel/inventory-consumer/internal/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func createTestConfig(enabled bool, enableOidcAuth bool) CompletedConfig {
+	options := &Options{
+		Enabled:        enabled,
+		InventoryURL:   "localhost:9090",
+		Insecure:       true,
+		EnableOidcAuth: enableOidcAuth,
+		ClientId:       "test-client",
+		ClientSecret:   "test-secret",
+		TokenEndpoint:  "http://localhost:8080/token",
+	}
+
+	return CompletedConfig{
+		&completedConfig{
+			Options: options,
+		},
+	}
+}
+
+func createTestLogger() *log.Helper {
+	_, logger := common.InitLogger("info", common.LoggerOptions{})
+	return log.NewHelper(log.With(logger, "service", "test"))
+}
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        CompletedConfig
+		expectEnabled bool
+		expectAuth    bool
+		shouldError   bool
+	}{
+		{
+			name:          "disabled client returns disabled KesselClient",
+			config:        createTestConfig(false, false),
+			expectEnabled: false,
+			expectAuth:    false,
+			shouldError:   false,
+		},
+		{
+			name:          "enabled client without auth creates client successfully",
+			config:        createTestConfig(true, false),
+			expectEnabled: true,
+			expectAuth:    false,
+			shouldError:   false,
+		},
+		{
+			name:          "enabled client with auth creates client successfully",
+			config:        createTestConfig(true, true),
+			expectEnabled: true,
+			expectAuth:    true,
+			shouldError:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger := createTestLogger()
+
+			client, err := New(test.config, logger)
+
+			if test.shouldError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, client)
+			assert.Equal(t, test.expectEnabled, client.Enabled)
+			assert.Equal(t, test.expectAuth, client.AuthEnabled)
+
+			if !test.config.Enabled {
+				// For disabled clients, InventoryClient should be nil
+				assert.Nil(t, client.InventoryClient)
+			} else {
+				// For enabled clients, InventoryClient should be set
+				assert.NotNil(t, client.InventoryClient)
+			}
+		})
+	}
+}
+
+func TestKesselClient_IsEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		enabled  bool
+		expected bool
+	}{
+		{
+			name:     "client is enabled",
+			enabled:  true,
+			expected: true,
+		},
+		{
+			name:     "client is disabled",
+			enabled:  false,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &KesselClient{
+				Enabled: test.enabled,
+			}
+
+			result := client.IsEnabled()
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+// TestClientProvider_CreateOrUpdateResource tests the CreateOrUpdateResource method using MockClient
+func TestClientProvider_CreateOrUpdateResource(t *testing.T) {
+	tests := []struct {
+		name           string
+		mockSetup      func(*mocks.MockClient)
+		request        *kesselv2.ReportResourceRequest
+		expectedResult *kesselv2.ReportResourceResponse
+		expectedError  error
+	}{
+		{
+			name: "successful create or update resource",
+			mockSetup: func(m *mocks.MockClient) {
+				m.On("CreateOrUpdateResource", mock.Anything).
+					Return(&kesselv2.ReportResourceResponse{}, nil)
+			},
+			request: &kesselv2.ReportResourceRequest{
+				Type:               "host",
+				ReporterType:       "hbi",
+				ReporterInstanceId: "test-instance",
+			},
+			expectedResult: &kesselv2.ReportResourceResponse{},
+			expectedError:  nil,
+		},
+		{
+			name: "create or update resource fails",
+			mockSetup: func(m *mocks.MockClient) {
+				m.On("CreateOrUpdateResource", mock.Anything).
+					Return(&kesselv2.ReportResourceResponse{}, errors.New("grpc error"))
+			},
+			request: &kesselv2.ReportResourceRequest{
+				Type:               "host",
+				ReporterType:       "hbi",
+				ReporterInstanceId: "test-instance",
+			},
+			expectedResult: &kesselv2.ReportResourceResponse{},
+			expectedError:  errors.New("grpc error"),
+		},
+		{
+			name: "create or update resource with specific request data",
+			mockSetup: func(m *mocks.MockClient) {
+				// Use mock.Anything for simpler matching
+				m.On("CreateOrUpdateResource", mock.Anything).
+					Return(&kesselv2.ReportResourceResponse{}, nil)
+			},
+			request: &kesselv2.ReportResourceRequest{
+				Type:               "host",
+				ReporterType:       "hbi",
+				ReporterInstanceId: "specific-instance",
+			},
+			expectedResult: &kesselv2.ReportResourceResponse{},
+			expectedError:  nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create mock client
+			mockClient := &mocks.MockClient{}
+			test.mockSetup(mockClient)
+
+			// Use the mock as ClientProvider interface
+			var client ClientProvider = mockClient
+
+			// Call the method being tested
+			result, err := client.CreateOrUpdateResource(test.request)
+
+			// Assert expectations
+			if test.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, test.expectedError.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, test.expectedResult, result)
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
+// TestClientProvider_DeleteResource tests the DeleteResource method using MockClient
+func TestClientProvider_DeleteResource(t *testing.T) {
+	tests := []struct {
+		name           string
+		mockSetup      func(*mocks.MockClient)
+		request        *kesselv2.DeleteResourceRequest
+		expectedResult *kesselv2.DeleteResourceResponse
+		expectedError  error
+	}{
+		{
+			name: "successful delete resource",
+			mockSetup: func(m *mocks.MockClient) {
+				m.On("DeleteResource", mock.Anything).
+					Return(&kesselv2.DeleteResourceResponse{}, nil)
+			},
+			request: &kesselv2.DeleteResourceRequest{
+				Reference: &kesselv2.ResourceReference{
+					ResourceType: "host",
+					ResourceId:   "test-host-id",
+					Reporter: &kesselv2.ReporterReference{
+						Type: "hbi",
+					},
+				},
+			},
+			expectedResult: &kesselv2.DeleteResourceResponse{},
+			expectedError:  nil,
+		},
+		{
+			name: "delete resource fails",
+			mockSetup: func(m *mocks.MockClient) {
+				m.On("DeleteResource", mock.Anything).
+					Return(&kesselv2.DeleteResourceResponse{}, errors.New("delete failed"))
+			},
+			request: &kesselv2.DeleteResourceRequest{
+				Reference: &kesselv2.ResourceReference{
+					ResourceType: "host",
+					ResourceId:   "test-host-id",
+					Reporter: &kesselv2.ReporterReference{
+						Type: "hbi",
+					},
+				},
+			},
+			expectedResult: &kesselv2.DeleteResourceResponse{},
+			expectedError:  errors.New("delete failed"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create mock client
+			mockClient := &mocks.MockClient{}
+			test.mockSetup(mockClient)
+
+			// Use the mock as ClientProvider interface
+			var client ClientProvider = mockClient
+
+			// Call the method being tested
+			result, err := client.DeleteResource(test.request)
+
+			// Assert expectations
+			if test.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, test.expectedError.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, test.expectedResult, result)
+			mockClient.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/client/options.go
+++ b/internal/client/options.go
@@ -30,8 +30,8 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 	}
 	fs.BoolVar(&o.Enabled, prefix+"enabled", o.Enabled, "enable the kessel inventory grpc client")
 	fs.StringVar(&o.InventoryURL, prefix+"url", o.InventoryURL, "gRPC endpoint of the kessel inventory service.")
-	fs.StringVar(&o.ClientId, prefix+"sa-client-id", o.ClientId, "service account client id")
-	fs.StringVar(&o.ClientSecret, prefix+"sa-client-secret", o.ClientSecret, "service account secret")
+	fs.StringVar(&o.ClientId, prefix+"client-id", o.ClientId, "service account client id")
+	fs.StringVar(&o.ClientSecret, prefix+"client-secret", o.ClientSecret, "service account secret")
 	fs.StringVar(&o.TokenEndpoint, prefix+"sso-token-endpoint", o.TokenEndpoint, "sso token endpoint for authentication")
 	fs.BoolVar(&o.EnableOidcAuth, prefix+"enable-oidc-auth", o.EnableOidcAuth, "enable oidc token auth to connect with Inventory API service")
 	fs.BoolVar(&o.Insecure, prefix+"insecure-client", o.Insecure, "the http client that connects to kessel should not verify certificates.")

--- a/internal/client/options_test.go
+++ b/internal/client/options_test.go
@@ -1,0 +1,83 @@
+package kessel
+
+import (
+	"testing"
+
+	"github.com/project-kessel/inventory-consumer/internal/common"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewOptions(t *testing.T) {
+	test := struct {
+		options         *Options
+		expectedOptions *Options
+	}{
+		options: NewOptions(),
+		expectedOptions: &Options{
+			Enabled:        true,
+			Insecure:       true,
+			EnableOidcAuth: false,
+		},
+	}
+	assert.Equal(t, test.expectedOptions, NewOptions())
+}
+
+func TestOptions_AddFlags(t *testing.T) {
+	test := struct {
+		options *Options
+	}{
+		options: NewOptions(),
+	}
+	prefix := "client"
+	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
+	test.options.AddFlags(fs, prefix)
+
+	// the below logic ensures that every possible option defined in the Options type
+	// has a defined flag for that option
+	common.AllOptionsHaveFlags(t, prefix, fs, *test.options, nil)
+}
+
+func TestOptions_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		options     *Options
+		expectError bool
+	}{
+		{
+			name: "inventory url is empty and the client is enabled",
+			options: &Options{
+				Enabled:      true,
+				InventoryURL: "",
+			},
+			expectError: true,
+		},
+		{
+			name: "inventory url is set and the client is enabled",
+			options: &Options{
+				Enabled:      true,
+				InventoryURL: "inventory-api:9000",
+			},
+			expectError: false,
+		},
+		{
+			name: "inventory url is empty and the client is disabled",
+			options: &Options{
+				Enabled:      false,
+				InventoryURL: "",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			errs := test.options.Validate()
+			if test.expectError {
+				assert.NotNil(t, errs)
+			} else {
+				assert.Nil(t, errs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Improvements to testing
* adds a few more unit tests for consumer package
* moves the parser tests to a new test file for cleanliness
* adds client unit tests
* updates the client flags for client-id and client-secret

For much of these tests, I leveraged cursor to build them out, following patterns we've already defined throughout our repo. The new client tests need revisiting to better align them with our other tests but they are sufficient to get something in there for now. Will review them and clean up, just wanted to start getting some tests added while im blocked on other PR's
