### PR TITLE
RHCLOUD-41550: migrates from inventory-api-client to go-sdk

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -12,12 +12,12 @@ import (
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/go-kratos/kratos/v2/log"
-	kesselv2 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
 	"github.com/project-kessel/inventory-consumer/consumer/auth"
 	"github.com/project-kessel/inventory-consumer/consumer/retry"
 	"github.com/project-kessel/inventory-consumer/consumer/transforms"
 	kessel "github.com/project-kessel/inventory-consumer/internal/client"
 	metricscollector "github.com/project-kessel/inventory-consumer/metrics"
+	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -319,7 +319,7 @@ func (i *InventoryConsumer) ProcessMessage(operation string, msg *kafka.Message)
 		i.Logger.Infof("processing message: operation=%s", operation)
 		i.Logger.Debugf("processed message=%s", msg.Value)
 
-		var req kesselv2.ReportResourceRequest
+		var req v1beta2.ReportResourceRequest
 		err := ParseCreateOrUpdateMessage(msg.Value, &req)
 		if err != nil {
 			metricscollector.Incr(i.MetricsCollector.MsgProcessFailures, "ParseCreateOrUpdateMessage", err)
@@ -344,7 +344,7 @@ func (i *InventoryConsumer) ProcessMessage(operation string, msg *kafka.Message)
 		i.Logger.Infof("processing message: operation=%s", operation)
 		i.Logger.Debugf("processed message=%s", msg.Value)
 
-		var req kesselv2.DeleteResourceRequest
+		var req v1beta2.DeleteResourceRequest
 		err := ParseDeleteMessage(msg.Value, &req)
 		if err != nil {
 			metricscollector.Incr(i.MetricsCollector.MsgProcessFailures, "ParseDeleteMessage", err)

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
-	kesselv2 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/project-kessel/inventory-consumer/internal/mocks"
@@ -19,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	. "github.com/project-kessel/inventory-api/cmd/common"
+	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
 )
 
 const (
@@ -83,7 +83,7 @@ func (t *TestCase) TestSetup() []error {
 	return errs
 }
 
-func makeReportResourceRequest() kesselv2.ReportResourceRequest {
+func makeReportResourceRequest() v1beta2.ReportResourceRequest {
 	commonData, _ := structpb.NewStruct(map[string]interface{}{
 		"workspace_id": "00000000-0000-0000-0000-000000000000",
 	})
@@ -95,12 +95,12 @@ func makeReportResourceRequest() kesselv2.ReportResourceRequest {
 		"ansible_host":            "my-ansible-host",
 	})
 
-	return kesselv2.ReportResourceRequest{
+	return v1beta2.ReportResourceRequest{
 		Type:               "host",
 		ReporterType:       "hbi",
 		ReporterInstanceId: "00000000-0000-0000-0000-000000000000",
-		Representations: &kesselv2.ResourceRepresentations{
-			Metadata: &kesselv2.RepresentationMetadata{
+		Representations: &v1beta2.ResourceRepresentations{
+			Metadata: &v1beta2.RepresentationMetadata{
 				LocalResourceId: "00000000-0000-0000-0000-000000000000",
 				ApiHref:         "https://apiHref.com/",
 				ConsoleHref:     ToPointer("https://www.console.com/"),
@@ -113,12 +113,12 @@ func makeReportResourceRequest() kesselv2.ReportResourceRequest {
 	}
 }
 
-func makeDeleteResourceRequest() kesselv2.DeleteResourceRequest {
-	return kesselv2.DeleteResourceRequest{
-		Reference: &kesselv2.ResourceReference{
+func makeDeleteResourceRequest() v1beta2.DeleteResourceRequest {
+	return v1beta2.DeleteResourceRequest{
+		Reference: &v1beta2.ResourceReference{
 			ResourceType: "host",
 			ResourceId:   "00000000-0000-0000-0000-000000000000",
-			Reporter: &kesselv2.ReporterReference{
+			Reporter: &v1beta2.ReporterReference{
 				Type: "hbi",
 			},
 		},
@@ -189,7 +189,7 @@ func TestInventoryConsumer_ProcessMessage(t *testing.T) {
 			},
 			clientEnabled: true,
 			setupMock: func(client *mocks.MockClient) {
-				client.On("CreateOrUpdateResource", mock.Anything).Return(&kesselv2.ReportResourceResponse{}, nil)
+				client.On("CreateOrUpdateResource", mock.Anything).Return(&v1beta2.ReportResourceResponse{}, nil)
 			},
 		},
 		{
@@ -201,7 +201,7 @@ func TestInventoryConsumer_ProcessMessage(t *testing.T) {
 			},
 			clientEnabled: true,
 			setupMock: func(client *mocks.MockClient) {
-				client.On("CreateOrUpdateResource", mock.Anything).Return(&kesselv2.ReportResourceResponse{}, nil)
+				client.On("CreateOrUpdateResource", mock.Anything).Return(&v1beta2.ReportResourceResponse{}, nil)
 			},
 		},
 		{
@@ -213,7 +213,7 @@ func TestInventoryConsumer_ProcessMessage(t *testing.T) {
 			},
 			clientEnabled: true,
 			setupMock: func(client *mocks.MockClient) {
-				client.On("DeleteResource", mock.Anything).Return(&kesselv2.DeleteResourceResponse{}, nil)
+				client.On("DeleteResource", mock.Anything).Return(&v1beta2.DeleteResourceResponse{}, nil)
 			},
 		},
 		{
@@ -242,7 +242,7 @@ func TestInventoryConsumer_ProcessMessage(t *testing.T) {
 			},
 			clientEnabled: true,
 			setupMock: func(client *mocks.MockClient) {
-				client.On("CreateOrUpdateResource", mock.Anything).Return(&kesselv2.ReportResourceResponse{}, nil)
+				client.On("CreateOrUpdateResource", mock.Anything).Return(&v1beta2.ReportResourceResponse{}, nil)
 			},
 		},
 		{
@@ -254,7 +254,7 @@ func TestInventoryConsumer_ProcessMessage(t *testing.T) {
 			},
 			clientEnabled: true,
 			setupMock: func(client *mocks.MockClient) {
-				client.On("DeleteResource", mock.Anything).Return(&kesselv2.DeleteResourceResponse{}, nil)
+				client.On("DeleteResource", mock.Anything).Return(&v1beta2.DeleteResourceResponse{}, nil)
 			},
 		},
 		{
@@ -267,7 +267,7 @@ func TestInventoryConsumer_ProcessMessage(t *testing.T) {
 			clientEnabled: true,
 			setupMock: func(client *mocks.MockClient) {
 				// Return NotFound error on first attempt, which should cause message to be dropped
-				client.On("DeleteResource", mock.Anything).Return(&kesselv2.DeleteResourceResponse{}, status.Error(codes.NotFound, "resource not found"))
+				client.On("DeleteResource", mock.Anything).Return(&v1beta2.DeleteResourceResponse{}, status.Error(codes.NotFound, "resource not found"))
 			},
 		},
 		{
@@ -280,8 +280,8 @@ func TestInventoryConsumer_ProcessMessage(t *testing.T) {
 			clientEnabled: true,
 			setupMock: func(client *mocks.MockClient) {
 				// Fail first attempt, succeed on second
-				client.On("CreateOrUpdateResource", mock.Anything).Return(&kesselv2.ReportResourceResponse{}, errors.New("temporary error")).Once()
-				client.On("CreateOrUpdateResource", mock.Anything).Return(&kesselv2.ReportResourceResponse{}, nil).Once()
+				client.On("CreateOrUpdateResource", mock.Anything).Return(&v1beta2.ReportResourceResponse{}, errors.New("temporary error")).Once()
+				client.On("CreateOrUpdateResource", mock.Anything).Return(&v1beta2.ReportResourceResponse{}, nil).Once()
 			},
 		},
 		{
@@ -294,8 +294,8 @@ func TestInventoryConsumer_ProcessMessage(t *testing.T) {
 			clientEnabled: true,
 			setupMock: func(client *mocks.MockClient) {
 				// Fail first attempt with non-NotFound error, succeed on second
-				client.On("DeleteResource", mock.Anything).Return(&kesselv2.DeleteResourceResponse{}, errors.New("temporary error")).Once()
-				client.On("DeleteResource", mock.Anything).Return(&kesselv2.DeleteResourceResponse{}, nil).Once()
+				client.On("DeleteResource", mock.Anything).Return(&v1beta2.DeleteResourceResponse{}, errors.New("temporary error")).Once()
+				client.On("DeleteResource", mock.Anything).Return(&v1beta2.DeleteResourceResponse{}, nil).Once()
 			},
 		},
 	}

--- a/consumer/parsers_test.go
+++ b/consumer/parsers_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
-	kesselv2 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -101,7 +101,7 @@ func TestParseHeaders(t *testing.T) {
 
 func TestParseCreateOrUpdateMessage(t *testing.T) {
 	expected := makeReportResourceRequest()
-	var req kesselv2.ReportResourceRequest
+	var req v1beta2.ReportResourceRequest
 	err := ParseCreateOrUpdateMessage([]byte(testCreateOrUpdateMessage), &req)
 	assert.Nil(t, err)
 	assert.Equal(t, expected.InventoryId, req.InventoryId)
@@ -115,7 +115,7 @@ func TestParseCreateOrUpdateMessage(t *testing.T) {
 
 func TestParseDeleteMessage(t *testing.T) {
 	expected := makeDeleteResourceRequest()
-	var req kesselv2.DeleteResourceRequest
+	var req v1beta2.DeleteResourceRequest
 	err := ParseDeleteMessage([]byte(testDeleteMessage), &req)
 	assert.Nil(t, err)
 	assert.Equal(t, expected.Reference.ResourceId, req.Reference.ResourceId)

--- a/consumer/transforms/hosts.go
+++ b/consumer/transforms/hosts.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"strings"
 
-	kesselv2 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
 	"github.com/project-kessel/inventory-consumer/consumer/types"
+	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
 )
 
 // TransformHostToReportResourceRequest transforms a Debezium message into a kesselv2.ReportResourceRequest
-func TransformHostToReportResourceRequest(msg []byte) (*kesselv2.ReportResourceRequest, error) {
+func TransformHostToReportResourceRequest(msg []byte) (*v1beta2.ReportResourceRequest, error) {
 	var hostMsg types.HostMessage
 	err := json.Unmarshal(msg, &hostMsg)
 	if err != nil {
@@ -48,7 +48,7 @@ func TransformHostToReportResourceRequest(msg []byte) (*kesselv2.ReportResourceR
 		return nil, fmt.Errorf("error marshaling intermediate payload: %v", err)
 	}
 
-	var request kesselv2.ReportResourceRequest
+	var request v1beta2.ReportResourceRequest
 	err = json.Unmarshal(payloadBytes, &request)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshaling to ReportResourceRequest: %v", err)
@@ -59,7 +59,7 @@ func TransformHostToReportResourceRequest(msg []byte) (*kesselv2.ReportResourceR
 
 // TransformHostToDeleteResourceRequest transforms a tombstone message into a kesselv2.DeleteResourceRequest
 // Extracts the resource ID from the message key since tombstones have empty values
-func TransformHostToDeleteResourceRequest(msgValue []byte, msgKey []byte) (*kesselv2.DeleteResourceRequest, error) {
+func TransformHostToDeleteResourceRequest(msgValue []byte, msgKey []byte) (*v1beta2.DeleteResourceRequest, error) {
 	// Extract ID from the key
 	if len(msgKey) == 0 {
 		return nil, fmt.Errorf("tombstone message has no key to extract resource ID")
@@ -81,11 +81,11 @@ func TransformHostToDeleteResourceRequest(msgValue []byte, msgKey []byte) (*kess
 		return nil, fmt.Errorf("cannot extract resource ID from tombstone message key")
 	}
 
-	return &kesselv2.DeleteResourceRequest{
-		Reference: &kesselv2.ResourceReference{
+	return &v1beta2.DeleteResourceRequest{
+		Reference: &v1beta2.ResourceReference{
 			ResourceType: types.HostResourceType,
 			ResourceId:   resourceID,
-			Reporter: &kesselv2.ReporterReference{
+			Reporter: &v1beta2.ReporterReference{
 				Type: types.HostReporterType,
 			},
 		},

--- a/consumer/transforms/hosts_test.go
+++ b/consumer/transforms/hosts_test.go
@@ -3,8 +3,8 @@ package transforms
 import (
 	"testing"
 
-	kesselv2 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
 	"github.com/project-kessel/inventory-consumer/consumer/types"
+	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -112,13 +112,13 @@ func TestTransformHostToReportResourceRequest(t *testing.T) {
 		message       []byte
 		expectError   bool
 		errorContains string
-		validate      func(*testing.T, *kesselv2.ReportResourceRequest)
+		validate      func(*testing.T, *v1beta2.ReportResourceRequest)
 	}{
 		{
 			name:        "valid host message transforms correctly",
 			message:     []byte(testHostMessageValid),
 			expectError: false,
-			validate: func(t *testing.T, req *kesselv2.ReportResourceRequest) {
+			validate: func(t *testing.T, req *v1beta2.ReportResourceRequest) {
 				assert.Equal(t, types.HostResourceType, req.Type)
 				assert.Equal(t, types.HostReporterType, req.ReporterType)
 				assert.Equal(t, types.HostReporterInstanceID, req.ReporterInstanceId)
@@ -147,7 +147,7 @@ func TestTransformHostToReportResourceRequest(t *testing.T) {
 			name:        "host message with multiple groups uses first group",
 			message:     []byte(testHostMessageMultipleGroups),
 			expectError: false,
-			validate: func(t *testing.T, req *kesselv2.ReportResourceRequest) {
+			validate: func(t *testing.T, req *v1beta2.ReportResourceRequest) {
 				commonMap := req.Representations.Common.AsMap()
 				assert.Equal(t, testWorkspaceID2, commonMap["workspace_id"])
 			},
@@ -222,14 +222,14 @@ func TestTransformHostToDeleteResourceRequest(t *testing.T) {
 		msgKey        []byte
 		expectError   bool
 		errorContains string
-		validate      func(*testing.T, *kesselv2.DeleteResourceRequest)
+		validate      func(*testing.T, *v1beta2.DeleteResourceRequest)
 	}{
 		{
 			name:        "valid tombstone transforms correctly",
 			msgValue:    []byte{},
 			msgKey:      []byte(testTombstoneKey),
 			expectError: false,
-			validate: func(t *testing.T, req *kesselv2.DeleteResourceRequest) {
+			validate: func(t *testing.T, req *v1beta2.DeleteResourceRequest) {
 				assert.NotNil(t, req.Reference)
 				assert.Equal(t, types.HostResourceType, req.Reference.ResourceType)
 				assert.Equal(t, testDeletedHostID, req.Reference.ResourceId)

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,8 @@ require (
 	github.com/authzed/grpcutil v0.0.0-20250221190651-1985b19b35b8
 	github.com/confluentinc/confluent-kafka-go/v2 v2.11.0
 	github.com/go-kratos/kratos/v2 v2.8.4
-	github.com/google/uuid v1.6.0
 	github.com/project-kessel/inventory-api v0.0.0-20250725190058-5b12d8b2493a
-	github.com/project-kessel/inventory-client-go v0.0.0-20250703155410-0ece2b1f2d03
+	github.com/project-kessel/kessel-sdk-go v0.0.0-20250724132447-5ed5147a4564
 	github.com/prometheus/client_golang v1.22.0
 	github.com/redhatinsights/app-common-go v1.6.8
 	github.com/spf13/cobra v1.9.1
@@ -40,7 +39,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-playground/form/v4 v4.2.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.3 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
@@ -48,7 +47,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
@@ -65,6 +63,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.37.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.41.0 // indirect
+	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/text v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,6 @@ github.com/gogo/googleapis v1.4.1 h1:1Yx4Myt7BxzvUr5ldGSbwYiZG6t9wGBZ+8/fX3Wvtq0
 github.com/gogo/googleapis v1.4.1/go.mod h1:2lpHqI5OcWCtVElxXnPt+s8oJvMpySlOyM6xDCrzib4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt/v5 v5.2.3 h1:kkGXqQOBSDDWRhWNXTFpqGSCMyh/PLnqUvMGJPDJDs0=
-github.com/golang-jwt/jwt/v5 v5.2.3/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -290,8 +288,6 @@ github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3I
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
-github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
@@ -306,8 +302,8 @@ github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b h1:0LFwY6Q3g
 github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/project-kessel/inventory-api v0.0.0-20250725190058-5b12d8b2493a h1:fIkW89mPCrR7ZIxGtKMJzGryPeskRGtP6CYmHqCmszw=
 github.com/project-kessel/inventory-api v0.0.0-20250725190058-5b12d8b2493a/go.mod h1:UqvXosFCZzjRKQ06WoQncYCMKlr30TAPDQJZHYF3nJQ=
-github.com/project-kessel/inventory-client-go v0.0.0-20250703155410-0ece2b1f2d03 h1:j6niKjfj0NmN/R30JJeX/1KwszvrlIklCQB0EDXvAgk=
-github.com/project-kessel/inventory-client-go v0.0.0-20250703155410-0ece2b1f2d03/go.mod h1:SyQfr20EDYld5nVQK/K2aLj2Uu9DETwvWzAZDCYB1yM=
+github.com/project-kessel/kessel-sdk-go v0.0.0-20250724132447-5ed5147a4564 h1:sV3RbQJ9krig2j8p+f0KMCSVRkp5lCI1h0qyzY45Xyk=
+github.com/project-kessel/kessel-sdk-go v0.0.0-20250724132447-5ed5147a4564/go.mod h1:QSUl9+RH0ZmvL4s5rfnUsmKXkp0i0S64e3QrPArjX5g=
 github.com/prometheus/client_golang v1.22.0 h1:rb93p9lokFEsctTys46VnV1kLCDpVZ0a/Y92Vm0Zc6Q=
 github.com/prometheus/client_golang v1.22.0/go.mod h1:R7ljNsLXhuQXYZYtw6GAE9AZg8Y7vEW5scdCXrWRXC0=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,15 +5,12 @@ import (
 	"fmt"
 
 	"github.com/go-kratos/kratos/v2/log"
-	kesselv2 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
-	"github.com/project-kessel/inventory-client-go/common"
-	v1beta2 "github.com/project-kessel/inventory-client-go/v1beta2"
-	"google.golang.org/grpc"
+	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
 )
 
 type ClientProvider interface {
-	CreateOrUpdateResource(request *kesselv2.ReportResourceRequest) (*kesselv2.ReportResourceResponse, error)
-	DeleteResource(request *kesselv2.DeleteResourceRequest) (*kesselv2.DeleteResourceResponse, error)
+	CreateOrUpdateResource(request *v1beta2.ReportResourceRequest) (*v1beta2.ReportResourceResponse, error)
+	DeleteResource(request *v1beta2.DeleteResourceRequest) (*v1beta2.DeleteResourceResponse, error)
 	IsEnabled() bool
 }
 
@@ -34,16 +31,20 @@ func New(c CompletedConfig, logger *log.Helper) (*KesselClient, error) {
 	}
 
 	if c.EnableOidcAuth {
-		client, err = v1beta2.New(common.NewConfig(
-			common.WithgRPCUrl(c.InventoryURL),
-			common.WithTLSInsecure(c.Insecure),
-			common.WithAuthEnabled(c.ClientId, c.ClientSecret, c.TokenEndpoint),
-		))
+		client, err = v1beta2.NewInventoryGRPCClientBuilder().
+			WithEndpoint(c.InventoryURL).
+			WithOAuth2(c.ClientId, c.ClientSecret, c.TokenEndpoint).
+			WithInsecure(c.Insecure).
+			WithMaxReceiveMessageSize(8 * 1024 * 1024).
+			WithMaxSendMessageSize(4 * 1024 * 1024).
+			Build()
 	} else {
-		client, err = v1beta2.New(common.NewConfig(
-			common.WithgRPCUrl(c.InventoryURL),
-			common.WithTLSInsecure(c.Insecure),
-		))
+		client, err = v1beta2.NewInventoryGRPCClientBuilder().
+			WithEndpoint(c.InventoryURL).
+			WithInsecure(c.Insecure).
+			WithMaxReceiveMessageSize(8 * 1024 * 1024).
+			WithMaxSendMessageSize(4 * 1024 * 1024).
+			Build()
 	}
 	if err != nil {
 		return &KesselClient{}, fmt.Errorf("failed to create Inventory API gRPC client: %w", err)
@@ -56,36 +57,16 @@ func New(c CompletedConfig, logger *log.Helper) (*KesselClient, error) {
 	}, nil
 }
 
-func (k *KesselClient) CreateOrUpdateResource(request *kesselv2.ReportResourceRequest) (*kesselv2.ReportResourceResponse, error) {
-	var opts []grpc.CallOption
-	var err error
-
-	if k.AuthEnabled {
-		opts, err = k.GetTokenCallOption()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get token option: %w", err)
-		}
-	}
-
-	resp, err := k.KesselInventoryService.ReportResource(context.Background(), request, opts...)
+func (k *KesselClient) CreateOrUpdateResource(request *v1beta2.ReportResourceRequest) (*v1beta2.ReportResourceResponse, error) {
+	resp, err := k.ReportResource(context.Background(), request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to report resource: %w", err)
 	}
 	return resp, nil
 }
 
-func (k *KesselClient) DeleteResource(request *kesselv2.DeleteResourceRequest) (*kesselv2.DeleteResourceResponse, error) {
-	var opts []grpc.CallOption
-	var err error
-
-	if k.AuthEnabled {
-		opts, err = k.GetTokenCallOption()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get token option: %w", err)
-		}
-	}
-
-	resp, err := k.KesselInventoryService.DeleteResource(context.Background(), request, opts...)
+func (k *KesselClient) DeleteResource(request *v1beta2.DeleteResourceRequest) (*v1beta2.DeleteResourceResponse, error) {
+	resp, err := k.DeleteResource(request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete resource: %w", err)
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/go-kratos/kratos/v2/log"
-	kesselv2 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
 	"github.com/project-kessel/inventory-consumer/internal/common"
 	"github.com/project-kessel/inventory-consumer/internal/mocks"
+	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -128,36 +128,36 @@ func TestClientProvider_CreateOrUpdateResource(t *testing.T) {
 	tests := []struct {
 		name           string
 		mockSetup      func(*mocks.MockClient)
-		request        *kesselv2.ReportResourceRequest
-		expectedResult *kesselv2.ReportResourceResponse
+		request        *v1beta2.ReportResourceRequest
+		expectedResult *v1beta2.ReportResourceResponse
 		expectedError  error
 	}{
 		{
 			name: "successful create or update resource",
 			mockSetup: func(m *mocks.MockClient) {
 				m.On("CreateOrUpdateResource", mock.Anything).
-					Return(&kesselv2.ReportResourceResponse{}, nil)
+					Return(&v1beta2.ReportResourceResponse{}, nil)
 			},
-			request: &kesselv2.ReportResourceRequest{
+			request: &v1beta2.ReportResourceRequest{
 				Type:               "host",
 				ReporterType:       "hbi",
 				ReporterInstanceId: "test-instance",
 			},
-			expectedResult: &kesselv2.ReportResourceResponse{},
+			expectedResult: &v1beta2.ReportResourceResponse{},
 			expectedError:  nil,
 		},
 		{
 			name: "create or update resource fails",
 			mockSetup: func(m *mocks.MockClient) {
 				m.On("CreateOrUpdateResource", mock.Anything).
-					Return(&kesselv2.ReportResourceResponse{}, errors.New("grpc error"))
+					Return(&v1beta2.ReportResourceResponse{}, errors.New("grpc error"))
 			},
-			request: &kesselv2.ReportResourceRequest{
+			request: &v1beta2.ReportResourceRequest{
 				Type:               "host",
 				ReporterType:       "hbi",
 				ReporterInstanceId: "test-instance",
 			},
-			expectedResult: &kesselv2.ReportResourceResponse{},
+			expectedResult: &v1beta2.ReportResourceResponse{},
 			expectedError:  errors.New("grpc error"),
 		},
 		{
@@ -165,14 +165,14 @@ func TestClientProvider_CreateOrUpdateResource(t *testing.T) {
 			mockSetup: func(m *mocks.MockClient) {
 				// Use mock.Anything for simpler matching
 				m.On("CreateOrUpdateResource", mock.Anything).
-					Return(&kesselv2.ReportResourceResponse{}, nil)
+					Return(&v1beta2.ReportResourceResponse{}, nil)
 			},
-			request: &kesselv2.ReportResourceRequest{
+			request: &v1beta2.ReportResourceRequest{
 				Type:               "host",
 				ReporterType:       "hbi",
 				ReporterInstanceId: "specific-instance",
 			},
-			expectedResult: &kesselv2.ReportResourceResponse{},
+			expectedResult: &v1beta2.ReportResourceResponse{},
 			expectedError:  nil,
 		},
 	}
@@ -208,44 +208,44 @@ func TestClientProvider_DeleteResource(t *testing.T) {
 	tests := []struct {
 		name           string
 		mockSetup      func(*mocks.MockClient)
-		request        *kesselv2.DeleteResourceRequest
-		expectedResult *kesselv2.DeleteResourceResponse
+		request        *v1beta2.DeleteResourceRequest
+		expectedResult *v1beta2.DeleteResourceResponse
 		expectedError  error
 	}{
 		{
 			name: "successful delete resource",
 			mockSetup: func(m *mocks.MockClient) {
 				m.On("DeleteResource", mock.Anything).
-					Return(&kesselv2.DeleteResourceResponse{}, nil)
+					Return(&v1beta2.DeleteResourceResponse{}, nil)
 			},
-			request: &kesselv2.DeleteResourceRequest{
-				Reference: &kesselv2.ResourceReference{
+			request: &v1beta2.DeleteResourceRequest{
+				Reference: &v1beta2.ResourceReference{
 					ResourceType: "host",
 					ResourceId:   "test-host-id",
-					Reporter: &kesselv2.ReporterReference{
+					Reporter: &v1beta2.ReporterReference{
 						Type: "hbi",
 					},
 				},
 			},
-			expectedResult: &kesselv2.DeleteResourceResponse{},
+			expectedResult: &v1beta2.DeleteResourceResponse{},
 			expectedError:  nil,
 		},
 		{
 			name: "delete resource fails",
 			mockSetup: func(m *mocks.MockClient) {
 				m.On("DeleteResource", mock.Anything).
-					Return(&kesselv2.DeleteResourceResponse{}, errors.New("delete failed"))
+					Return(&v1beta2.DeleteResourceResponse{}, errors.New("delete failed"))
 			},
-			request: &kesselv2.DeleteResourceRequest{
-				Reference: &kesselv2.ResourceReference{
+			request: &v1beta2.DeleteResourceRequest{
+				Reference: &v1beta2.ResourceReference{
 					ResourceType: "host",
 					ResourceId:   "test-host-id",
-					Reporter: &kesselv2.ReporterReference{
+					Reporter: &v1beta2.ReporterReference{
 						Type: "hbi",
 					},
 				},
 			},
-			expectedResult: &kesselv2.DeleteResourceResponse{},
+			expectedResult: &v1beta2.DeleteResourceResponse{},
 			expectedError:  errors.New("delete failed"),
 		},
 	}

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -2,7 +2,7 @@ package mocks
 
 import (
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
-	kesselv2 "github.com/project-kessel/inventory-api/api/kessel/inventory/v1beta2"
+	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -44,14 +44,14 @@ func (m *MockConsumer) AssignmentLost() bool {
 	return args.Get(0).(bool)
 }
 
-func (m *MockClient) CreateOrUpdateResource(request *kesselv2.ReportResourceRequest) (*kesselv2.ReportResourceResponse, error) {
+func (m *MockClient) CreateOrUpdateResource(request *v1beta2.ReportResourceRequest) (*v1beta2.ReportResourceResponse, error) {
 	args := m.Called(request)
-	return args.Get(0).(*kesselv2.ReportResourceResponse), args.Error(1)
+	return args.Get(0).(*v1beta2.ReportResourceResponse), args.Error(1)
 }
 
-func (m *MockClient) DeleteResource(request *kesselv2.DeleteResourceRequest) (*kesselv2.DeleteResourceResponse, error) {
+func (m *MockClient) DeleteResource(request *v1beta2.DeleteResourceRequest) (*v1beta2.DeleteResourceResponse, error) {
 	args := m.Called(request)
-	return args.Get(0).(*kesselv2.DeleteResourceResponse), args.Error(1)
+	return args.Get(0).(*v1beta2.DeleteResourceResponse), args.Error(1)
 }
 
 func (m *MockClient) IsEnabled() bool {


### PR DESCRIPTION
Replaces all use of inventory-client-go with the new kessel-go-sdk

UPDATE: validated in ephemeral for both HBI host migration and outbox messages and everything is working as expected

DOUBLE UPDATED: validated in ephemeral using stage SSO to confirm auth works as well

```shell
# proof auth is enabled in invenotry api and no token/bad token fails API call
$ oc get cm inventory-api-config -o yaml | grep -A 5 authn
    authn:
      oidc:
        authn-server-url: https://REDACTED
        client-id: "REDACTED"
        skip-client-id-check: true
        insecure-client: false

# calling API without a token fails
$ ./scripts/load-generator.sh -i 1 -n 1 -p 8000
Creating resource...
{"code":401,"reason":"UNAUTHORIZED","message":"Unauthorized","metadata":{}}Updating resource...
{"code":401,"reason":"UNAUTHORIZED","message":"Unauthorized","metadata":{}}Deleting resource...
{"code":401,"reason":"UNAUTHORIZED","message":"Unauthorized","metadata":{}

# KIC configured with client auth
$ oc get cm kic-config -o yaml | grep -A 7 client
    client:
      enabled: true
      url: "kessel-inventory-api:9000"
      client-id: "REDACTED (using its own client)"
      client-secret: "REDACTED (using its own client)"
      sso-token-endpoint: https://https://REDACTED
      insecure-client: true
      enable-oidc-auth: true

# validation of HBI migration successful
$ oc rsh host-inventory-db-687bd8c9df-rvh48 psql -h localhost -d host-inventory -c "select count(*) from hbi.hosts;"
 count 
-------
  1000
(1 row)

# KIC Logs showing all replication completed
INFO ts=2025-08-04T14:55:01Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=response: 
INFO ts=2025-08-04T14:55:01Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=consumed event from topic host-inventory.hbi.hosts, partition 0 at offset 999

# Inventory DB matches count of HBI
$ oc rsh kessel-inventory-db-f86fbb654-tll6m psql -h localhost -d kessel-inventory -c "select count(*) from resources;"
 count 
-------
  1000
(1 row)

# validates replication to relations via token count
 select count(*) from resources where consistency_token IS NOT NULL and consistency_token <> '';                                              
 count 
-------
  1000
(1 row)
```