### PR TITLE
adds support for providing a CA cert for validation when using auth to Kafka cluster

### DIFF
--- a/consumer/auth/options.go
+++ b/consumer/auth/options.go
@@ -8,6 +8,7 @@ type Options struct {
 	SASLMechanism    string `mapstructure:"sasl-mechanism"`
 	SASLUsername     string `mapstructure:"sasl-username"`
 	SASLPassword     string `mapstructure:"sasl-password"`
+	CACertLocation   string `mapstructure:"ca-cert-location"`
 }
 
 func NewOptions() *Options {
@@ -25,4 +26,5 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 	fs.StringVar(&o.SASLMechanism, prefix+"sasl-mechanism", o.SASLMechanism, "sets the SASL mechanism")
 	fs.StringVar(&o.SASLUsername, prefix+"sasl-username", o.SASLUsername, "sets the username to use for authentication")
 	fs.StringVar(&o.SASLPassword, prefix+"sasl-password", o.SASLPassword, "sets the password to use for authentication")
+	fs.StringVar(&o.CACertLocation, prefix+"ca-cert-location", o.CACertLocation, "sets the location of the Kafka clusters' CA certificate")
 }

--- a/consumer/config.go
+++ b/consumer/config.go
@@ -60,6 +60,7 @@ func (c *Config) Complete() (CompletedConfig, []error) {
 				"sasl.mechanism":    c.AuthConfig.SASLMechanism,
 				"sasl.username":     c.AuthConfig.SASLUsername,
 				"sasl.password":     c.AuthConfig.SASLPassword,
+				"ssl.ca.location":   c.AuthConfig.CACertLocation,
 			}
 			for key, value := range authSettings {
 				if err := config.SetKey(key, value); err != nil {

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -91,6 +91,7 @@ func New(config CompletedConfig, client kessel.ClientProvider, logger *log.Helpe
 		SASLMechanism:    config.AuthConfig.SASLMechanism,
 		SASLUsername:     config.AuthConfig.SASLUsername,
 		SASLPassword:     config.AuthConfig.SASLPassword,
+		CACertLocation:   config.AuthConfig.CACertLocation,
 	}
 
 	retryOptions := &retry.Options{

--- a/deploy/kessel-inventory-consumer.yaml
+++ b/deploy/kessel-inventory-consumer.yaml
@@ -32,10 +32,16 @@ objects:
             volumeMounts:
                 - name: config-volume
                   mountPath: "/inventory"
+                - name: kafka-ca-certs
+                  mountPath: "/kafka-ca-certs"
             volumes:
               - name: config-volume
                 secret:
                   secretName: kessel-inventory-consumer-config
+              - name: kafka-ca-certs
+                secret:
+                  secretName: ${CA_CERT_SECRET}
+                  optional: true
             readinessProbe:
               exec:
                 command: ["inventory-consumer", "readyz"]
@@ -71,3 +77,6 @@ parameters:
   - description: Number of replicas
     name: REPLICAS
     value: "3"
+  - description: Name of Secret that contains the Kafka clusters' CA Cert (if required)
+    name: CA_CERT_SECRET
+    value: kessel-kafka-connect-config


### PR DESCRIPTION
implements same functionality as https://github.com/project-kessel/inventory-api/pull/792
This allows KIC (if needed) to accept a CA cert file and define the path to allow for SSL validation when talking to a Kafka cluster configured for TLS