### PR TITLE
adds topics to clowdapp for kafka auth injection

### DIFF
--- a/deploy/kessel-inventory-consumer.yaml
+++ b/deploy/kessel-inventory-consumer.yaml
@@ -9,10 +9,9 @@ objects:
       name: kessel-inventory-consumer
     spec:
       envName: ${ENV_NAME}
-      # uncomment once topics have been created
-      # kafkaTopics:
-      # - topicName: outbox.event.hbi.hosts
-      # - topicName: host-inventory.hbi.hosts
+      kafkaTopics:
+      - topicName: outbox.event.hbi.hosts
+      - topicName: host-inventory.hbi.hosts
       optionalDependencies:
         - kessel-inventory
         - kessel-relations


### PR DESCRIPTION
Adds HBI topics to clowdapp so that Kafka auth/endpoints are captured by Clowder and injected into pods