### PR TITLE
Experiment sending JWT over insecure gRPC connection

### DIFF
--- a/.inventory-consumer.yaml
+++ b/.inventory-consumer.yaml
@@ -14,5 +14,7 @@ client:
   url: "localhost:9000"
   enable-oidc-auth: false
   insecure-client: true
+  # optional: static JWT sent as Per-RPC credentials when insecure-client is true (no TLS)
+  # bearer-token: "<your-jwt>"
 log:
   level: "info"

--- a/development/configs/full-setup.yaml
+++ b/development/configs/full-setup.yaml
@@ -14,7 +14,11 @@ consumer:
 client:
   enabled: true
   url: "inventory-api:9081"
-  enable-oidc-auth: false
   insecure-client: true
+  enable-oidc-auth: true
+  client-id: "<client-id>"
+  client-secret: "<client-secret"
+  # Must be the token URL that accepts POST (client_credentials), not the realm root
+  sso-token-endpoint: "https://example.com/token"  
 log:
-  level: "info"
+  level: "debug"

--- a/development/docker-compose.yaml
+++ b/development/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
     restart: "always"
     networks:
       - kessel
-    scale: 3
+    scale: 1
 
   hbidatabase:
     image: "postgres"

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/project-kessel/kessel-sdk-go/kessel/auth"
 	kesselgrpc "github.com/project-kessel/kessel-sdk-go/kessel/grpc"
 	"github.com/project-kessel/kessel-sdk-go/kessel/inventory/v1beta2"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
 
@@ -24,11 +25,14 @@ type KesselClient struct {
 	v1beta2.KesselInventoryServiceClient
 	Enabled     bool
 	AuthEnabled bool
+	// callOpts are applied to each RPC when set (e.g. Per-RPC JWT over insecure gRPC).
+	callOpts []grpc.CallOption
 }
 
 func New(c CompletedConfig, logger *log.Helper) (*KesselClient, error) {
 	logger.Info("Setting up Inventory API client")
 	var client v1beta2.KesselInventoryServiceClient
+	var callOpts []grpc.CallOption
 	var err error
 
 	if !c.Enabled {
@@ -36,46 +40,51 @@ func New(c CompletedConfig, logger *log.Helper) (*KesselClient, error) {
 		return &KesselClient{Enabled: false}, nil
 	}
 
-	if c.EnableOidcAuth {
+	// TLS + OIDC: use SDK Authenticated with channel credentials.
+	if c.EnableOidcAuth && !c.Insecure {
 		oauthCredentials := auth.NewOAuth2ClientCredentials(c.ClientId, c.ClientSecret, c.TokenEndpoint)
-		// TODO: Build can return a grpc.ClientConn for closing the connection
-		// need to investigate where this could be implemented, security/performance, etc
 		channelCreds, err := configureTLS(c.CACertFile)
 		if err != nil {
 			return &KesselClient{}, fmt.Errorf("failed to setup transport credentials for TLS: %w", err)
 		}
 		client, _, err = v1beta2.NewClientBuilder(c.InventoryURL).
 			Authenticated(kesselgrpc.OAuth2CallCredentials(&oauthCredentials), channelCreds).Build()
-
 		if err != nil {
 			return &KesselClient{}, fmt.Errorf("failed to create gRPC client: %w", err)
 		}
+	} else if c.Insecure {
+		// Insecure gRPC: build with SDK Insecure(), then attach JWT via Per-RPC credentials (no SDK changes).
+		client, _, err = v1beta2.NewClientBuilder(c.InventoryURL).Insecure().Build()
+		if err != nil {
+			return &KesselClient{}, fmt.Errorf("failed to create inventory client: %w", err)
+		}
+		if c.BearerToken != "" {
+			callOpts = []grpc.CallOption{WithInsecureBearerToken(c.BearerToken)}
+		} else if c.EnableOidcAuth {
+			callOpts = []grpc.CallOption{grpc.PerRPCCredentials(&insecureOAuth2PerRPCCreds{
+				clientID: c.ClientId, clientSecret: c.ClientSecret, tokenEndpoint: c.TokenEndpoint,
+			})}
+		}
 	} else {
-		if c.Insecure {
-			client, _, err = v1beta2.NewClientBuilder(c.InventoryURL).Insecure().Build()
-			if err != nil {
-				return &KesselClient{}, fmt.Errorf("failed to create inventory client: %w", err)
-			}
-		} else {
-			channelCreds, err := configureTLS(c.CACertFile)
-			if err != nil {
-				return &KesselClient{}, fmt.Errorf("failed to setup transport credentials for TLS: %w", err)
-			}
-			client, _, err = v1beta2.NewClientBuilder(c.InventoryURL).Unauthenticated(channelCreds).Build()
-			if err != nil {
-				return &KesselClient{}, fmt.Errorf("failed to create inventory client: %w", err)
-			}
+		channelCreds, err := configureTLS(c.CACertFile)
+		if err != nil {
+			return &KesselClient{}, fmt.Errorf("failed to setup transport credentials for TLS: %w", err)
+		}
+		client, _, err = v1beta2.NewClientBuilder(c.InventoryURL).Unauthenticated(channelCreds).Build()
+		if err != nil {
+			return &KesselClient{}, fmt.Errorf("failed to create inventory client: %w", err)
 		}
 	}
 	return &KesselClient{
 		KesselInventoryServiceClient: client,
 		Enabled:                      c.Enabled,
 		AuthEnabled:                  c.EnableOidcAuth,
+		callOpts:                     callOpts,
 	}, nil
 }
 
 func (k *KesselClient) ReportResource(request *v1beta2.ReportResourceRequest) (*v1beta2.ReportResourceResponse, error) {
-	resp, err := k.KesselInventoryServiceClient.ReportResource(context.Background(), request)
+	resp, err := k.KesselInventoryServiceClient.ReportResource(context.Background(), request, k.callOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to report resource: %w", err)
 	}
@@ -83,7 +92,7 @@ func (k *KesselClient) ReportResource(request *v1beta2.ReportResourceRequest) (*
 }
 
 func (k *KesselClient) DeleteResource(request *v1beta2.DeleteResourceRequest) (*v1beta2.DeleteResourceResponse, error) {
-	resp, err := k.KesselInventoryServiceClient.DeleteResource(context.Background(), request)
+	resp, err := k.KesselInventoryServiceClient.DeleteResource(context.Background(), request, k.callOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete resource: %w", err)
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -23,6 +23,10 @@ import (
 )
 
 func createTestConfig(enabled bool, enableOidcAuth bool, caCertFile string) CompletedConfig {
+	return createTestConfigWithBearer(enabled, enableOidcAuth, caCertFile, "")
+}
+
+func createTestConfigWithBearer(enabled bool, enableOidcAuth bool, caCertFile string, bearerToken string) CompletedConfig {
 	options := &Options{
 		Enabled:        enabled,
 		InventoryURL:   "localhost:9000",
@@ -32,6 +36,7 @@ func createTestConfig(enabled bool, enableOidcAuth bool, caCertFile string) Comp
 		ClientId:       "test-client",
 		ClientSecret:   "test-secret",
 		TokenEndpoint:  "http://localhost:8080/token",
+		BearerToken:    bearerToken,
 	}
 
 	return CompletedConfig{
@@ -160,6 +165,14 @@ func TestNew(t *testing.T) {
 			expectAuth:    true,
 			shouldError:   false,
 			useInMemory:   true,
+		},
+		{
+			name:          "enabled client with insecure and bearer token creates client successfully",
+			config:        createTestConfigWithBearer(true, false, "", "test-jwt-token"),
+			expectEnabled: true,
+			expectAuth:    false,
+			shouldError:   false,
+			useInMemory:   false,
 		},
 	}
 

--- a/internal/client/credentials.go
+++ b/internal/client/credentials.go
@@ -1,0 +1,66 @@
+package kessel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/project-kessel/kessel-sdk-go/kessel/auth"
+	"google.golang.org/grpc"
+)
+
+// insecureBearerCreds implements credentials.PerRPCCredentials and adds a
+// Bearer token to outgoing gRPC metadata. RequireTransportSecurity returns false
+// so the token can be sent over an insecure (non-TLS) connection, matching
+// inventory-api's WithInsecureBearerToken behavior when talking to relations-api.
+type insecureBearerCreds struct {
+	token string
+}
+
+// GetRequestMetadata returns the Authorization header with the bearer token.
+func (c insecureBearerCreds) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
+	if c.token == "" {
+		return nil, nil
+	}
+	return map[string]string{
+		"authorization": fmt.Sprintf("Bearer %s", c.token),
+	}, nil
+}
+
+// RequireTransportSecurity returns false to allow sending the token over insecure gRPC.
+func (insecureBearerCreds) RequireTransportSecurity() bool {
+	return false
+}
+
+// insecureOAuth2PerRPCCreds implements credentials.PerRPCCredentials by
+// obtaining a token via OAuth2 client credentials and attaching it to each RPC.
+// RequireTransportSecurity returns false so it can be used over insecure gRPC.
+// Stores client id/secret/endpoint so no pointer to stack-allocated auth is kept.
+type insecureOAuth2PerRPCCreds struct {
+	clientID       string
+	clientSecret   string
+	tokenEndpoint  string
+}
+
+// GetRequestMetadata fetches an OAuth2 token and returns the Authorization header.
+func (c *insecureOAuth2PerRPCCreds) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
+	oauthCredentials := auth.NewOAuth2ClientCredentials(c.clientID, c.clientSecret, c.tokenEndpoint)
+	tok, err := oauthCredentials.GetToken(ctx, auth.GetTokenOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{
+		"authorization": fmt.Sprintf("Bearer %s", tok.AccessToken),
+	}, nil
+}
+
+// RequireTransportSecurity returns false to allow use over insecure gRPC.
+func (*insecureOAuth2PerRPCCreds) RequireTransportSecurity() bool {
+	return false
+}
+
+// WithInsecureBearerToken returns a grpc.CallOption that adds a Bearer token
+// to the request metadata and allows insecure transport (no TLS).
+// Use this when connecting to inventory-api over plain gRPC but still sending a JWT.
+func WithInsecureBearerToken(token string) grpc.CallOption {
+	return grpc.PerRPCCredentials(insecureBearerCreds{token: token})
+}

--- a/internal/client/options.go
+++ b/internal/client/options.go
@@ -15,6 +15,9 @@ type Options struct {
 	ClientId       string `mapstructure:"client-id"`
 	ClientSecret   string `mapstructure:"client-secret"`
 	TokenEndpoint  string `mapstructure:"sso-token-endpoint"`
+	// BearerToken is an optional static JWT sent as Per-RPC credentials when Insecure is true.
+	// Allows sending a valid JWT over insecure gRPC (no TLS) without changing the SDK.
+	BearerToken string `mapstructure:"bearer-token"`
 }
 
 func NewOptions() *Options {
@@ -37,6 +40,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet, prefix string) {
 	fs.StringVar(&o.ClientSecret, prefix+"client-secret", o.ClientSecret, "service account secret")
 	fs.StringVar(&o.TokenEndpoint, prefix+"sso-token-endpoint", o.TokenEndpoint, "sso token endpoint for authentication")
 	fs.BoolVar(&o.EnableOidcAuth, prefix+"enable-oidc-auth", o.EnableOidcAuth, "enable oidc token auth to connect with Inventory API service")
+	fs.StringVar(&o.BearerToken, prefix+"bearer-token", o.BearerToken, "optional static JWT sent as Per-RPC credentials when using insecure gRPC to Inventory API")
 
 }
 
@@ -47,8 +51,9 @@ func (o *Options) Validate() []error {
 		errs = append(errs, fmt.Errorf("kessel url may not be empty"))
 	}
 
-	if o.EnableOidcAuth && o.Insecure {
-		errs = append(errs, fmt.Errorf("enable-oidc-auth and insecure cannot be both true"))
+	// Insecure + JWT (BearerToken or OIDC) is allowed: JWT is sent via Per-RPC credentials.
+	if o.EnableOidcAuth && o.Insecure && o.BearerToken != "" {
+		errs = append(errs, fmt.Errorf("cannot set both bearer-token and enable-oidc-auth when insecure"))
 	}
 
 	return errs

--- a/internal/client/options_test.go
+++ b/internal/client/options_test.go
@@ -77,10 +77,21 @@ func TestOptions_Validate(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "enable oidc auth is enabled and insecure is enabled",
+			name: "enable oidc auth is enabled and insecure is enabled (JWT over insecure gRPC allowed)",
 			options: &Options{
 				Insecure:       true,
 				EnableOidcAuth: true,
+				InventoryURL:   "localhost:9000",
+			},
+			expectError: false,
+		},
+		{
+			name: "both bearer-token and enable-oidc-auth when insecure is invalid",
+			options: &Options{
+				Insecure:       true,
+				EnableOidcAuth: true,
+				BearerToken:    "a-token",
+				InventoryURL:   "localhost:9000",
 			},
 			expectError: true,
 		},


### PR DESCRIPTION
- Sends a JWT over insecure gRPC connection to invenotry-api
- config changes, helper methods added to facilitate the same