### PR TITLE
RHCLOUD-48027: adds HCC clusters to prometheus source regex in dashboard

### DIFF
--- a/dashboards/grafana-dashboard-kessel-inventory-consumer.configmap.yaml
+++ b/dashboards/grafana-dashboard-kessel-inventory-consumer.configmap.yaml
@@ -1281,7 +1281,7 @@ data:
             "options": [],
             "query": "prometheus",
             "refresh": 1,
-            "regex": "/(crcp01ue1-prometheus)|(crcfrp01ugw1-prometheus)|(crcs02ue1-prometheus)|(crcfrs01ugw1-prometheus)|(insights-perf-prometheus)/",
+            "regex": "/(crcp01ue1-prometheus)|(crcfrp01ugw1-prometheus)|(crcs02ue1-prometheus)|(crcfrs01ugw1-prometheus)|(insights-perf-prometheus)|(hccs01ue1-prometheus)|(hccp01ue1-prometheus)/",
             "type": "datasource"
           },
           {


### PR DESCRIPTION
Updates the datasource regex to include HCC clusters