### PR TITLE
RHCLOUD-48065: Bump go to 1.26.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,5 +18,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.6.2
+          version: v2.12.2
           args: --timeout=10m

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/project-kessel/inventory-consumer
 
-go 1.25.7
+go 1.26.2
 
 require (
 	github.com/confluentinc/confluent-kafka-go/v2 v2.14.1

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -70,7 +70,7 @@ func IsNil(i interface{}) bool {
 		return true
 	}
 	switch reflect.TypeOf(i).Kind() {
-	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.UnsafePointer, reflect.Interface, reflect.Slice:
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Pointer, reflect.UnsafePointer, reflect.Interface, reflect.Slice:
 		return reflect.ValueOf(i).IsNil()
 	case reflect.Array:
 		return reflect.ValueOf(i).IsZero()


### PR DESCRIPTION
- go.mod bumped to 1.26.2
- golangci-lint.yml updated to v2.12.2
- reflect.Ptr -> reflect.Pointer in internal/common/common.go