### PR TITLE
RHCLOUD-48845: migrates to hummingbird, removes docs related to service deployer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782366411 AS builder
-
-ARG TARGETARCH
-USER root
-RUN microdnf install -y tar gzip make which gcc gcc-c++ cyrus-sasl-lib findutils git go-toolset
+# Build stage -- the Go toolchain embeds the validated FIPS module in all binaries automatically.
+FROM registry.access.redhat.com/hi/go:1.26.4-fips AS builder
 
 WORKDIR /workspace
 
 COPY go.mod go.sum ./
 
-ENV CGO_ENABLED 1
 RUN go mod download
 
 COPY cmd ./cmd
@@ -20,9 +16,14 @@ COPY main.go Makefile ./
 ARG VERSION
 RUN VERSION=${VERSION} make build
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782366411
+# Runtime stage -- set GODEBUG so the binary runs in FIPS mode.
+FROM registry.access.redhat.com/hi/core-runtime:2.42-openssl-fips
+
+WORKDIR /
 
 COPY --from=builder /workspace/bin/inventory-consumer /usr/local/bin/
+
+ENV GODEBUG=fips140=on
 
 USER 1001
 ENV PATH="$PATH:/usr/local/bin"

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,11 @@
-FIPS_ENABLED?=true
-
 GOHOSTOS:=$(shell go env GOHOSTOS)
 GOPATH:=$(shell go env GOPATH)
 GOOS?=$(shell go env GOOS)
 GOARCH?=$(shell go env GOARCH)
 GOBIN?=$(shell go env GOBIN)
-GOFLAGS_MOD ?=
 
-GOENV=GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=1 GOFLAGS="${GOFLAGS_MOD}"
+GOENV=GOOS=${GOOS} GOARCH=${GOARCH}
 GOBUILDFLAGS=-gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"
-
-ifeq (${FIPS_ENABLED}, true)
-GOFLAGS_MOD+=-tags=fips_enabled
-GOFLAGS_MOD:=$(strip ${GOFLAGS_MOD})
-GOENV+=GOEXPERIMENT=strictfipsruntime,boringcrypto
-GOENV:=$(strip ${GOENV})
-endif
 
 IMAGE ?="quay.io/cloudservices/kessel-inventory"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
@@ -32,12 +22,7 @@ endif
 .PHONY: build
 # build
 build:
-	$(warning Setting GOEXPERIMENT=strictfipsruntime,boringcrypto - this generally causes builds to fail unless building inside the provided Dockerfile. If building locally, run `make local-build`)
-	mkdir -p bin/ && ${GOENV} GOOS=${GOOS} go build ${GOBUILDFLAGS} -ldflags "-X cmd.Version=$(VERSION)" -o ./bin/ ./...
-
-.PHONY: local-build
-local-build:
-	mkdir -p bin/ && go build -ldflags "-X cmd.Version=$(VERSION)" -o ./bin/ ./...
+	mkdir -p bin/ && ${GOENV} go build ${GOBUILDFLAGS} -ldflags "-X cmd.Version=$(VERSION)" -o ./bin/ ./...
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The Kessel Inventory Consumer (KIC) is a standalone dedicated Kafka consumer group used to expose an eventing based entry point to the Kessel Inventory API. Its purpose is to subscribe to Service Provider owned Kafka topics and ensure reporter resource updates are replicated to Inventory API through events.
 
 ### To Build:
-`make local-build`
+`make build`
 
 ### To Build Container Image:
 

--- a/docs/dev-guides/hbi-testing-testing.md
+++ b/docs/dev-guides/hbi-testing-testing.md
@@ -95,37 +95,3 @@ podman logs relations-api-relations-api-1
 # access resources in Inventory API DB
 psql -h localhost -p 5433 -d spicedb -U postgres # requires password available in Inventory API repo
 ```
-
-# Ephemeral HBI Migration Testing
-
-To test HBI Migration (or outbox processing) using Debezium, it is recommend to leverage the ephemeral process using the insights-service-deployer script. This will ensure the latest HBI code changes and database schema changes as to avoid false negatives/positives in testing. See the [HBI Migration runbook](https://github.com/project-kessel/insights-service-deployer/blob/main/docs/hbi-migration-runbook.md) for the process
-
-### Ad-Hoc Snapshots
-
-If you're testing HBI with Debezium using the above ephemeral process, you can also test performing blocking and incremental snapshots through Debeizum.
-
-To trigger the snapshot:
-
-1. Spin up the Kessel Debug container
-
-```shell
-oc process --local \
-    -f https://raw.githubusercontent.com/project-kessel/inventory-api/refs/heads/main/tools/kessel-debug-container/kessel-debug-deploy.yaml \
-    -p ENV="env-$(oc project)" | oc apply -f -
-
-# rsh to the debug container
-oc rsh kessel-debug
-
-# Setup Kafka env vars
-source /usr/local/bin/env-setup.sh
-```
-
-2. Trigger the snapshot by producing an event to the snapshot table
-
-```bash
-# For a blocking snapshot
-echo 'host-inventory|{"type":"execute-snapshot","data":{"data-collections":["hbi.hosts"],"type":"blocking"}}' | kcat -P -b $BOOTSTRAP_SERVERS -t host-inventory.signal -K "|"
-
-# For an incremental snapshot
-echo 'host-inventory|{"type":"execute-snapshot","data":{"data-collections":["hbi.hosts"],"type":"INCREMENTAL"}}' | kcat -P -b $BOOTSTRAP_SERVERS -t host-inventory.signal -K "|"
-```


### PR DESCRIPTION
### Changes:
* Migrates Inventory Consumer base images to use Hummingbird hardened images
* Updates any relevant make targets and build flags similar to https://github.com/project-kessel/inventory-api/pull/1389
* Removes instructions and links to dev testing doc for insights-service-deployer as its deprecated

### Validation


```shell
### In Ephemeral
# Custom image build using hummingbird
$ oc get pod kessel-inventory-consumer-service-5bb47464d4-mxvrm -o yaml | grep image:
    image: quay.io/anatale/inventory-consumer-hummingbird:40ac09d
    image: quay.io/anatale/inventory-consumer-hummingbird:40ac09d
    
# Deployed via bonfire deploy kessel, spun up kcat pod and add HBI host event to HBI outbox topic
$ echo 'BIG-LONG-HBI-EVENT-TRUNCATED'| kcat -P -b $BOOTSTRAP_SERVERS -H "operation=ReportResource" -H "version=v1beta2" -t outbox.event.hbi.hosts -K "|"

# KIC processes HBI outbox event
INFO ts=2026-06-30T19:07:00Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=processing message: operation=ReportResource, version=v1beta2
INFO ts=2026-06-30T19:07:00Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=offsets committed ([partition:offset]): [0:0]
INFO ts=2026-06-30T19:07:00Z caller=log/log.go:30 service.name=inventory-consumer service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=consumed event from topic outbox.event.hbi.hosts, partition 0 at offset 0

# Inventory ReportResource successful, IIC handles replication
INFO ts=2026-06-30T19:07:00Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= service.id=kessel-inventory-api-7f6d7bc864-q2ddh msg=Creating new resource
INFO ts=2026-06-30T19:07:00Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= service.id=kessel-inventory-api-7f6d7bc864-q2ddh msg=Tuple event to write to outbox : &{ID:00000000-0000-0000-0000-000000000000 AggregateType:kessel.tuples AggregateID:019f19ed-74c5-791a-a377-63308f8fc0e4 Operation:created TxId:019f19ed-74c0-712a-bc03-2813b9e1a8df Payload:map[common_version:0 reporter_representation_version:0 reporter_resource_key:map[local_resource_id:dd1b73b9-3e33-4264-968c-e3ce55b9afec reporter:map[reporter_instance_id:redhat reporter_type:hbi] resource_type:host]]}
INFO ts=2026-06-30T19:07:00Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= service.id=kessel-inventory-api-7f6d7bc864-q2ddh msg=outbox event successfully converted to WAL message: id=019f19ed-74cb-7176-93d4-a6d59ac2fa9e, aggregateType=kessel.resources, aggregateid=019f19ed-74c5-791a-a377-63308f8fc0e4
INFO ts=2026-06-30T19:07:00Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= service.id=kessel-inventory-api-7f6d7bc864-q2ddh msg=outbox event successfully converted to WAL message: id=019f19ed-74cb-7cea-a081-a2a76b50573b, aggregateType=kessel.tuples, aggregateid=019f19ed-74c5-791a-a377-63308f8fc0e4
----
INFO ts=2026-06-30T19:07:00Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=processing message: operation=created, txid=019f19ed-74c0-712a-bc03-2813b9e1a8df
INFO ts=2026-06-30T19:07:00Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= service.id=kessel-inventory-api-7f6d7bc864-q2ddh msg=Creating tuples: 1
INFO ts=2026-06-30T19:07:00Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=offsets committed ([partition:offset]): [0:0]
INFO ts=2026-06-30T19:07:00Z caller=log/log.go:30 service.name=inventory-api service.version=0.1.0 trace.id= span.id= subsystem=inventoryConsumer msg=consumed event from topic outbox.event.kessel.tuples, partition 0 at offset 0
```

Also works with `kessel-up` compose integration test using the custom image
```shell
$ make kessel-compose-integration-test
./scripts/kessel-integration-test.sh

=== Step 0: Prerequisites Check ===
  ✓ PASS: All prerequisites installed

=== Step 1: Service Health Checks ===
  ✓ PASS: Inventory API is ready
  ✓ PASS: Relations API is ready
  ✓ PASS: RBAC is ready
  ✓ PASS: Kafka Connect is ready

=== Step 2: Bootstrap Tenant via RBAC V2 ===
[INFO] Triggering tenant bootstrap for org_id=test-org-kessel-e2e
  ✓ PASS: Tenant bootstrapped — default workspace: 019f1a09-fa58-7410-9428-82d3f00ff93c
  ✓ PASS: Root workspace: 019f1a09-fa58-7410-9428-82c958c8483f

=== Step 3: Verify Workspace Hierarchy in Relations API ===
[INFO] Polling Relations API for workspace tuples (up to 60s)...
  ✓ PASS: Found 6 workspace tuples in Relations API
  ✓ PASS: Default workspace has parent relationship to root workspace

=== Step 4: Publish Simulated HBI Host Event via kcat ===
[INFO] Publishing HBI host event to outbox.event.hbi.hosts
[INFO]   host_id=e2e10000-0000-0000-0000-42fa243269c7, workspace_id=019f1a09-fa58-7410-9428-82d3f00ff93c
  ✓ PASS: HBI host event published to Kafka

=== Step 5: Wait for Consumer Processing ===
[INFO] Polling Inventory API for the reported resource (up to 30s)...
  ✓ PASS: Resource confirmed in Inventory API (host_id=e2e10000-0000-0000-0000-42fa243269c7)

=== Step 6: Verify Resource-to-Workspace Tuple in Relations API ===
[INFO] Polling Relations API for host tuples (up to 60s)...
  ✓ PASS: Found 1 host tuple(s) in Relations API
  ✓ PASS: Host resource is linked to workspace 019f1a09-fa58-7410-9428-82d3f00ff93c

=== Step 7: RBAC Access Check ===
[INFO] Polling RBAC V2 roles (up to 60s for CDC replication)...
  ✓ PASS: RBAC V2 has 10 roles for tenant
  ✓ PASS: RBAC V2 lists 2 workspaces (root + default + any user-created)

=== Step 8: Resource Deletion Flow ===
[INFO] Deleting resource via Inventory API gRPC
  ✓ PASS: Resource deleted from Inventory API
[INFO] Waiting for tuple cleanup (up to 30s)...
  ✓ PASS: Host-to-workspace tuple removed from Relations API after deletion

=== Summary ===

  Passed: 17  /  Failed: 0  /  Total: 17

All integration tests passed.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build and runtime setup to use FIPS-enabled Go and core runtime images.
  * Simplified the standard build command used for local and CI builds.

* **Documentation**
  * Revised build instructions to use `make build`.
  * Updated testing guidance with direct database connection steps and removed outdated snapshot instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->