### PR TITLE
RHCLOUD-48849: adds agent readiness guides with modifications to improve coderabbit use

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# See https://docs.coderabbit.ai/reference/configuration for all fields and default values
+knowledge_base:
+  learnings:
+    scope: global
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "**/AGENTS.md"
+      - "**/CLAUDE.md"
+      - "**/CONTRIBUTING.md"
+      - "**/GUIDELINES.md"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,156 @@
+## Guidelines Index
+
+**All guidelines in this file and the linked docs are mandatory, not recommendations.** Agents MUST read the relevant guideline doc before making changes in that area and MUST follow every rule.
+
+| Layer | File | Scope |
+|-------|------|-------|
+| Consumer Core | [consumer/GUIDELINES.md](consumer/GUIDELINES.md) | Kafka consumption, offset management, retry, shutdown coordination |
+| Transforms | [consumer/transforms/GUIDELINES.md](consumer/transforms/GUIDELINES.md) | CDC message transforms, service provider onboarding |
+| Client | [internal/client/GUIDELINES.md](internal/client/GUIDELINES.md) | gRPC client, TLS/OIDC auth, SDK usage |
+| Configuration | [internal/config/GUIDELINES.md](internal/config/GUIDELINES.md) | Options/Config/CompletedConfig pattern, Clowder, Viper |
+| Metrics | [metrics/GUIDELINES.md](metrics/GUIDELINES.md) | OpenTelemetry metrics, Prometheus, Grafana alignment |
+
+## Repository Context
+
+The Kessel Inventory Consumer (KIC) is a standalone Kafka consumer group that subscribes to service-provider-owned Kafka topics and replicates resource updates to the Kessel Inventory API via gRPC. The Go module is `github.com/project-kessel/inventory-consumer`. It currently serves one service provider (Host Based Inventory / HBI) but is designed to onboard additional providers.
+
+Key external dependencies:
+- `confluent-kafka-go/v2` -- Kafka consumer (wraps librdkafka)
+- `kessel-sdk-go` -- gRPC SDK for the Kessel Inventory API (v1beta2)
+- `go-kratos/kratos/v2` -- logging framework
+- `spf13/cobra` + `spf13/viper` + `spf13/pflag` -- CLI, config file, and flag management
+- `opentelemetry` + `prometheus` -- metrics pipeline
+- `redhatinsights/app-common-go` -- ClowdApp config injection for Red Hat cloud environments
+
+## Architecture Overview
+
+The processing pipeline flows through these stages:
+
+```
+Kafka Topic -> Poll Loop (consumer.go) -> ParseHeaders -> ProcessMessage
+  -> [ReportResource|DeleteResource]: ParseCreateOrUpdateMessage / ParseDeleteMessage -> gRPC Client
+  -> [migration]: transforms package -> gRPC Client
+```
+
+Package boundaries:
+
+| Package | Responsibility |
+|---------|---------------|
+| `cmd/` | Cobra commands (`start`, `readyz`), config wiring, signal handling |
+| `consumer/` | Kafka consumer loop, message parsing, retry, offset management, shutdown |
+| `consumer/auth/` | Kafka SASL authentication config |
+| `consumer/retry/` | Retry parameter config |
+| `consumer/transforms/` | CDC-to-protobuf transforms for raw Debezium messages |
+| `consumer/types/` | Domain types for CDC source systems |
+| `internal/client/` | gRPC client wrapping kessel-sdk-go |
+| `internal/config/` | Top-level `OptionsConfig` aggregation, ClowdApp injection |
+| `internal/common/` | Shared utilities (logging, reflection helpers) |
+| `internal/mocks/` | testify/mock implementations of `Consumer` and `ClientProvider` |
+| `metrics/` | OTel meter setup, Prometheus exporter, stats collection |
+
+## Options / Config / CompletedConfig Pattern
+
+Every configurable component uses a three-tier lifecycle: `Options` -> `Config` -> `CompletedConfig`. This is the central design pattern of the codebase. The full specification is in [internal/config/GUIDELINES.md](internal/config/GUIDELINES.md). Key points for cross-package awareness:
+
+- `CompletedConfig` wraps an unexported `completedConfig` to prevent construction without calling `Complete()`.
+- The required call sequence is: `options.Complete()` -> `options.Validate()` -> `NewConfig(options).Complete()`. See `cmd/start.go` for the canonical example.
+- Every `Options` field must have a `mapstructure` tag, a corresponding pflag in `AddFlags()`, and a matching YAML key in `.inventory-consumer.yaml`.
+- Adding a new component requires wiring into `internal/config/OptionsConfig`, the relevant command in `cmd/`, and the config file.
+
+## Error Handling
+
+- `Validate()` methods return `[]error` (a slice), not a single error. Collect all failures rather than short-circuiting.
+- gRPC errors from `ClientProvider` methods are wrapped with `fmt.Errorf("failed to <action>: %w", err)`.
+- Sentinel errors (`ErrClosed`, `ErrMaxRetries`, `ErrValidation`) drive control flow in the consumer loop. `ErrClosed` triggers consumer-level restart; `ErrMaxRetries` propagates fatal failure; `ErrValidation` (from header parsing) exits the consume loop.
+- Domain-specific gRPC status codes (e.g., `codes.NotFound` on delete) are handled via custom error handler functions passed to `Retry()`.
+
+## Testing
+
+- **Framework**: `github.com/stretchr/testify` (assert + mock).
+- **Pattern**: Table-driven tests with `t.Run(test.name, ...)` subtests.
+- **Test scaffolding**: Use the `TestCase` struct and `TestSetup()` in the consumer package to bootstrap tests with Options, Config, CompletedConfig, MockConsumer, and InventoryConsumer.
+- **Mocks**: `internal/mocks/mocks.go` provides `MockConsumer` (implements `consumer.Consumer` interface) and `MockClient` (implements `kessel.ClientProvider`). Both use testify/mock.
+- **Flag coverage**: Every Options package has a test using `common.AllOptionsHaveFlags()` to verify that all `mapstructure`-tagged fields have registered pflags. Adding a field without a flag will fail this test.
+- **Metrics coverage**: The `metricscollector_test.go` test uses reflection to verify every field on `MetricsCollector` is initialized after `New()`. Adding a metric field without registering it will fail this test.
+- **Race tests**: `race_condition_test.go` tests concurrent shutdown/rebalance scenarios. Always run tests with the `-race` flag.
+- **Test data**: Test message JSON and UUIDs are defined as package-level `const` values. Reuse existing constants rather than creating new fixtures.
+
+## Build, Test, and Lint
+
+```shell
+make build          # Compile to ./bin/inventory-consumer
+make test           # Run all tests with -race and coverage
+make lint           # Run golangci-lint v2.6.2 via container
+make lint-fix       # Run golangci-lint with --fix
+```
+
+Tests run with `-count=1 -race -short -covermode=atomic`. CI (GitHub Actions) runs both `build-test` and `golangci-lint` on every push/PR to main. The Go version is read from `go.mod`.
+
+## Local Development
+
+Local development requires the Kessel network of services. The recommended approach uses Podman Compose:
+
+1. Clone and start Inventory API: `make inventory-up-relations-ready` (in the inventory-api repo)
+2. Clone and start Relations API: `make relations-api-up` (in the relations-api repo)
+3. Start KIC and dependencies: `make inventory-consumer-up` (in this repo)
+
+This spins up KIC (3 replicas), a test HBI PostgreSQL database, Kafka topic creation, and a Debezium Kafka Connect cluster. The compose setup uses the external `kessel` Docker network. Config is read from `development/configs/full-setup.yaml`.
+
+Other useful Makefile targets:
+- `make setup-hbi-db` -- load the HBI schema into the test database
+- `make setup-connectors` / `make delete-connectors` -- manage Debezium connectors
+- `make check-connector-status` -- check connector health
+
+## Docker and FIPS
+
+The Dockerfile uses a two-stage build with Red Hat FIPS-validated base images. The runtime stage sets `GODEBUG=fips140=on`. The entrypoint is `inventory-consumer` with default command `start`. The binary runs as non-root user 1001.
+
+## Deployment
+
+KIC deploys as a ClowdApp on OpenShift (see `deploy/kessel-inventory-consumer.yaml`). Key deployment details:
+- Default 3 replicas with a PodDisruptionBudget (minAvailable: 1)
+- Readiness probe runs `inventory-consumer readyz` (gRPC health check against inventory-api)
+- Config is injected via a Kubernetes Secret mounted at `/inventory/kic-config.yaml`
+- ClowdApp integration: when `CLOWDER_ENABLED=true`, Kafka broker addresses and SASL credentials are injected from the ClowdApp config at startup (see `internal/config/config.go`)
+- Tekton pipelines in `.tekton/` handle PR and push builds via Konflux
+
+## CI/CD Pipelines
+
+- **GitHub Actions**: `build-test.yml` (build + unit tests), `golangci-lint.yml` (linting), `codeql.yml` (security analysis), `jira-check.yml` (PR Jira ticket validation)
+- **Tekton/Konflux**: PR and push pipelines build container images and push to Quay
+
+## Monitoring
+
+Prometheus metrics are served on port 9000 at `/metrics`. The Grafana dashboard ConfigMap in `dashboards/` queries specific metric names -- renaming or adding metrics requires updating the dashboard to match. See [metrics/GUIDELINES.md](metrics/GUIDELINES.md) for the full naming and registration rules.
+
+## Adding a New Service Provider
+
+This is the most common extension task. The full procedure is in [consumer/transforms/GUIDELINES.md](consumer/transforms/GUIDELINES.md). Summary of cross-package touchpoints:
+
+1. Create domain types in `consumer/types/<provider>_types.go`
+2. Create transform functions in `consumer/transforms/<provider>.go`
+3. Add routing logic in `consumer/consumer.go` `ProcessMessage()` (new case or topic-based dispatch)
+4. Add the topic to `.inventory-consumer.yaml` and `development/configs/full-setup.yaml`
+5. Add the topic to the ClowdApp manifest in `deploy/`
+6. Update mocks and tests as needed
+
+## Adding a New API Operation
+
+1. Add the method to `ClientProvider` interface in `internal/client/client.go`
+2. Implement it on `KesselClient`
+3. Add the method to `MockClient` in `internal/mocks/mocks.go`
+4. Add the operation constant and `ProcessMessage` case in `consumer/consumer.go`
+5. Add to `validOperations` map in `consumer/consumer.go`
+
+## Naming Conventions
+
+- **Go packages**: lowercase, single-word where possible
+- **CLI flags**: dot-separated hierarchy with kebab-case segments (e.g., `consumer.auth.sasl-mechanism`)
+- **YAML config keys**: match the `mapstructure` tag values exactly (kebab-case)
+- **Metric names**: `consumer_stats_` prefix for Kafka stats, `consumer_` prefix for app-level counters, snake_case after prefix
+- **Constants**: provider-specific constants follow `<Provider>ResourceType`, `<Provider>ReporterType` naming in `consumer/types/`
+- **Operation types**: string constants in `consumer.go` (e.g., `OperationTypeReportResource`)
+
+## Logging
+
+Logging uses `go-kratos/kratos/v2/log`. The log level is configurable via the `log.level` YAML key (debug, info, warn, error, fatal; defaults to info). Each subsystem creates a `log.Helper` scoped with a `subsystem` key. Debug-level logging includes full config dumps (via `config.LogConfigurationInfo`) and message payloads. Never log secrets (passwords, tokens).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Key external dependencies:
 
 The processing pipeline flows through these stages:
 
-```
+```text
 Kafka Topic -> Poll Loop (consumer.go) -> ParseHeaders -> ProcessMessage
   -> [ReportResource|DeleteResource]: ParseCreateOrUpdateMessage / ParseDeleteMessage -> gRPC Client
   -> [migration]: transforms package -> gRPC Client
@@ -153,4 +153,4 @@ This is the most common extension task. The full procedure is in [consumer/trans
 
 ## Logging
 
-Logging uses `go-kratos/kratos/v2/log`. The log level is configurable via the `log.level` YAML key (debug, info, warn, error, fatal; defaults to info). Each subsystem creates a `log.Helper` scoped with a `subsystem` key. Debug-level logging includes full config dumps (via `config.LogConfigurationInfo`) and message payloads. Never log secrets (passwords, tokens).
+Logging uses `go-kratos/kratos/v2/log`. The log level is configurable via the `log.level` YAML key (debug, info, warn, error, fatal; defaults to info). Each subsystem creates a `log.Helper` scoped with a `subsystem` key. Debug-level logging includes full config dumps (via `config.LogConfigurationInfo`) and full Kafka message payloads (key and value are logged via `msg.Value` and `msg.Key` in `Consume()` and `ProcessMessage()`). Never log secrets (passwords, tokens). When adding debug logging, limit output to sanitized metadata -- avoid logging raw message bodies in new code paths.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# Kessel Inventory Consumer -- Claude Code Configuration
+
+## Build and Test Commands
+
+```shell
+make build          # Compile to ./bin/inventory-consumer
+make test           # Run all tests with -race and coverage
+make lint           # Run golangci-lint v2.6.2 via container
+make lint-fix       # Run golangci-lint with --fix
+```
+
+## Before Committing
+
+1. Run `make test` -- tests include race detector and coverage
+2. Run `make lint` -- catches style issues
+3. No pre-commit hooks are configured in this repo
+
+## CI Checks
+
+GitHub Actions runs `build-test` and `golangci-lint` on every push/PR to main. Both must pass. Go version is read from `go.mod`. Tekton/Konflux pipelines build container images on PR and push.
+
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 
 The Kessel Inventory Consumer (KIC) is a standalone dedicated Kafka consumer group used to expose an eventing based entry point to the Kessel Inventory API. Its purpose is to subscribe to Service Provider owned Kafka topics and ensure reporter resource updates are replicated to Inventory API through events.
 
+### Project Structure
+
+```
+cmd/                       CLI commands (start, readyz) and config wiring
+consumer/                  Core Kafka consumer loop, message parsing, retry, shutdown
+  transforms/              CDC-to-protobuf transforms for Debezium messages
+  types/                   Domain types for CDC source systems
+internal/client/           gRPC client wrapping kessel-sdk-go
+internal/config/           Top-level config aggregation, ClowdApp injection
+metrics/                   OpenTelemetry metrics and Prometheus exporter
+deploy/                    OpenShift ClowdApp manifests
+development/               Local Podman Compose setup and configs
+```
+
+### Documentation
+
+- [AGENTS.md](./AGENTS.md) -- AI agent onboarding, architecture overview, and conventions
+- Guidelines -- mandatory rules for each subsystem:
+  - [consumer/GUIDELINES.md](./consumer/GUIDELINES.md) -- Kafka consumption, offset management, retry, shutdown
+  - [consumer/transforms/GUIDELINES.md](./consumer/transforms/GUIDELINES.md) -- CDC transforms, service provider onboarding
+  - [internal/client/GUIDELINES.md](./internal/client/GUIDELINES.md) -- gRPC client, TLS/OIDC auth, SDK usage
+  - [internal/config/GUIDELINES.md](./internal/config/GUIDELINES.md) -- Options/Config/CompletedConfig pattern, Clowder, Viper
+  - [metrics/GUIDELINES.md](./metrics/GUIDELINES.md) -- OpenTelemetry metrics, Prometheus, Grafana alignment
+- [docs/dev-guides/](./docs/dev-guides/) -- Development guides (e.g., HBI testing)
+- [docs/runbooks/](./docs/runbooks/) -- Operational runbooks for troubleshooting and incident response
+
 ### To Build:
 `make build`
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 The Kessel Inventory Consumer (KIC) is a standalone dedicated Kafka consumer group used to expose an eventing based entry point to the Kessel Inventory API. Its purpose is to subscribe to Service Provider owned Kafka topics and ensure reporter resource updates are replicated to Inventory API through events.
 
-### Project Structure
+## Project Structure
 
-```
+```text
 cmd/                       CLI commands (start, readyz) and config wiring
 consumer/                  Core Kafka consumer loop, message parsing, retry, shutdown
   transforms/              CDC-to-protobuf transforms for Debezium messages
@@ -16,7 +16,7 @@ deploy/                    OpenShift ClowdApp manifests
 development/               Local Podman Compose setup and configs
 ```
 
-### Documentation
+## Documentation
 
 - [AGENTS.md](./AGENTS.md) -- AI agent onboarding, architecture overview, and conventions
 - Guidelines -- mandatory rules for each subsystem:

--- a/consumer/GUIDELINES.md
+++ b/consumer/GUIDELINES.md
@@ -28,13 +28,13 @@
 - `Shutdown()` sets `shutdownInProgress = true` under the lock before committing remaining offsets and closing the consumer. This flag prevents the rebalance callback from double-committing.
 - `RebalanceCallback()` checks `shutdownInProgress` under the lock. If true, it skips the offset commit and returns nil. If false and there are no stored offsets, it returns early. Otherwise it commits.
 - The `RebalanceCallback` signature must satisfy `func(*kafka.Consumer, kafka.Event) error`. The method receives a `*kafka.Consumer` parameter but uses `i.Consumer` (the InventoryConsumer's embedded consumer) instead. Do not use the passed-in consumer parameter.
-- `Shutdown()` always returns `ErrClosed`. The `Consume()` loop treats `ErrClosed` as a restartable condition; any other error from Shutdown is wrapped and propagated as fatal.
+- `Shutdown()` returns `ErrClosed` on successful or already-closed shutdown. If the underlying `Consumer.Close()` fails, it returns that error instead. The `Consume()` loop treats `ErrClosed` as a restartable condition; any non-`ErrClosed` error from Shutdown is wrapped and propagated as fatal.
 
 ## Two-Level Retry Strategy
 
 - **Consumer-level retry** (`Run()`): When `Consume()` returns `ErrClosed`, the entire consumer is recreated with a new Kafka connection and the loop restarts. This re-reads the current message from the earliest uncommitted offset. Controlled by `ConsumerMaxRetries` (default 2). Set to -1 for infinite retries.
 - **Operation-level retry** (`Retry()`): Individual gRPC operations (ReportResource, DeleteResource) are retried with backoff within a single consume cycle. Controlled by `OperationMaxRetries` (default 3). Set to -1 for infinite retries.
-- Backoff formula: `min(BackoffFactor * attempts * 300ms, MaxBackoffSeconds)`. Same formula at both levels.
+- Backoff formula: `min(BackoffFactor * attempts * 300ms, MaxBackoffSeconds * time.Second)`. Same formula at both levels. The maximum is expressed in seconds in the config but converted to a `time.Duration` in the calculation.
 - `Retry()` accepts optional variadic `errorHandler` functions. If the first handler returns true, the retry loop short-circuits and returns `(nil, nil)` -- the message is silently dropped. Used for NotFound errors on delete operations.
 - When `Retry()` exhausts max retries, it returns `ErrMaxRetries`. This causes `ProcessMessage` to fail, which causes `Consume()` to exit the loop and trigger shutdown.
 
@@ -43,7 +43,7 @@
 - Messages must have two Kafka headers: `operation` and `version`. Both are required and validated against allow-lists (`validOperations`, `validApiVersions`).
 - Extra headers beyond the required set are silently ignored (filtered by `requiredHeaders` map during parsing).
 - Header parsing uses `mapstructure` with `ErrorUnused: true` to decode into `EventHeaders`.
-- Validation errors are wrapped with `ErrValidation` sentinel. Missing/invalid headers cause the consume loop to exit (`run = false`), triggering consumer-level restart.
+- Validation errors are wrapped with `ErrValidation` sentinel. Missing/invalid headers cause the consume loop to exit (`run = false`), triggering consumer-level restart. Because the offset is only stored after successful `ProcessMessage`, a malformed message that fails header validation will replay on restart. The current behavior is intentional -- the consumer restarts and retries the same message. If a permanently malformed message causes infinite replay, it must be addressed by skipping the record or routing it to a dead-letter queue at the application level.
 - Message body follows the Debezium outbox pattern: `{"schema": {...}, "payload": {...}}`. The `MessagePayload.RequestPayload` field is an `interface{}` that gets re-marshaled to JSON then unmarshaled into the target protobuf type.
 - `ParseCreateOrUpdateMessage` extracts `transaction_id` from `payload.representations.metadata.transaction_id` and sets it as the protobuf `IdempotencyKey` oneof. This only applies to `ReportResourceRequest`; other types are silently skipped.
 - `ParseDeleteMessage` does not extract transaction_id.

--- a/consumer/GUIDELINES.md
+++ b/consumer/GUIDELINES.md
@@ -1,0 +1,76 @@
+## Options / Config / CompletedConfig Pattern
+
+- Every package in the consumer tree follows a three-stage configuration pattern: `Options` (user-facing flags) -> `Config` (intermediate, mutable) -> `CompletedConfig` (immutable, constructed only via `Config.Complete()`).
+- `CompletedConfig` wraps an unexported `completedConfig` struct. This prevents external construction -- callers must go through `Complete()`.
+- `NewOptions()` must set all defaults. `AddFlags()` registers pflag bindings with a dot-separated prefix (e.g. `consumer.auth.enabled`). `Validate()` returns `[]error`, not a single error.
+- `Options.Complete()` returns `[]error` (not `(CompletedConfig, error)`). `Config.Complete()` returns `(CompletedConfig, []error)`. Follow the existing signature when adding new fields.
+- When adding a new sub-package config (like auth or retry), embed its `*Options` in the parent `Options`, its `*Config` in the parent `Config`, and wire `NewConfig()` to call the sub-package's `NewConfig()`.
+- `Config.KafkaConfig` can be injected directly (for testing) or built from Options during `Complete()`. If `c.KafkaConfig != nil`, it is used as-is; otherwise it is constructed from option fields.
+- Auth settings are only added to the Kafka config map when `AuthConfig.Enabled` is true.
+
+## Consumer Interface and Dependency Injection
+
+- The `Consumer` interface abstracts `confluent-kafka-go`'s consumer. It contains only the methods actually used: `CommitOffsets`, `SubscribeTopics`, `Poll`, `IsClosed`, `Close`, `AssignmentLost`. Do not add methods to this interface unless the consumer loop needs them.
+- `New()` accepts an optional `Consumer` parameter. When nil, a real Kafka consumer is created from config. When non-nil (tests), the provided mock is used. This is the primary injection point for testing.
+- The `ClientProvider` interface (from `internal/client`) is similarly injected. Check `client.IsEnabled()` before making gRPC calls -- the client can be disabled, in which case message processing succeeds without API calls.
+
+## Offset Management
+
+- Auto-commit is disabled (`enable.auto.commit = false`). Offsets are committed manually via `CommitStoredOffsets()`.
+- Offsets accumulate in `OffsetStorage` (a `[]kafka.TopicPartition` slice) and are batch-committed when the current offset satisfies the modulo condition: `int(offset) % CommitModulo == 0`.
+- `CommitModulo` must be a positive non-zero integer (validated in `Options.Validate()`). Default is 10.
+- `CommitStoredOffsets()` copies the slice, clears `OffsetStorage`, releases the mutex, then calls `CommitOffsets`. On failure, it re-acquires the mutex and restores or merges the offsets back. This copy-then-commit pattern prevents holding the lock during the blocking Kafka call.
+- During operation-level retries (`Retry()`), stored offsets are committed before sleeping for backoff. This prevents offset starvation during long retry loops.
+
+## Shutdown and Rebalance Coordination
+
+- `offsetMutex` (sync.Mutex) protects `OffsetStorage` and `shutdownInProgress`. Every read or write to these fields must hold the lock.
+- `Shutdown()` sets `shutdownInProgress = true` under the lock before committing remaining offsets and closing the consumer. This flag prevents the rebalance callback from double-committing.
+- `RebalanceCallback()` checks `shutdownInProgress` under the lock. If true, it skips the offset commit and returns nil. If false and there are no stored offsets, it returns early. Otherwise it commits.
+- The `RebalanceCallback` signature must satisfy `func(*kafka.Consumer, kafka.Event) error`. The method receives a `*kafka.Consumer` parameter but uses `i.Consumer` (the InventoryConsumer's embedded consumer) instead. Do not use the passed-in consumer parameter.
+- `Shutdown()` always returns `ErrClosed`. The `Consume()` loop treats `ErrClosed` as a restartable condition; any other error from Shutdown is wrapped and propagated as fatal.
+
+## Two-Level Retry Strategy
+
+- **Consumer-level retry** (`Run()`): When `Consume()` returns `ErrClosed`, the entire consumer is recreated with a new Kafka connection and the loop restarts. This re-reads the current message from the earliest uncommitted offset. Controlled by `ConsumerMaxRetries` (default 2). Set to -1 for infinite retries.
+- **Operation-level retry** (`Retry()`): Individual gRPC operations (ReportResource, DeleteResource) are retried with backoff within a single consume cycle. Controlled by `OperationMaxRetries` (default 3). Set to -1 for infinite retries.
+- Backoff formula: `min(BackoffFactor * attempts * 300ms, MaxBackoffSeconds)`. Same formula at both levels.
+- `Retry()` accepts optional variadic `errorHandler` functions. If the first handler returns true, the retry loop short-circuits and returns `(nil, nil)` -- the message is silently dropped. Used for NotFound errors on delete operations.
+- When `Retry()` exhausts max retries, it returns `ErrMaxRetries`. This causes `ProcessMessage` to fail, which causes `Consume()` to exit the loop and trigger shutdown.
+
+## Message Processing Pipeline
+
+- Messages must have two Kafka headers: `operation` and `version`. Both are required and validated against allow-lists (`validOperations`, `validApiVersions`).
+- Extra headers beyond the required set are silently ignored (filtered by `requiredHeaders` map during parsing).
+- Header parsing uses `mapstructure` with `ErrorUnused: true` to decode into `EventHeaders`.
+- Validation errors are wrapped with `ErrValidation` sentinel. Missing/invalid headers cause the consume loop to exit (`run = false`), triggering consumer-level restart.
+- Message body follows the Debezium outbox pattern: `{"schema": {...}, "payload": {...}}`. The `MessagePayload.RequestPayload` field is an `interface{}` that gets re-marshaled to JSON then unmarshaled into the target protobuf type.
+- `ParseCreateOrUpdateMessage` extracts `transaction_id` from `payload.representations.metadata.transaction_id` and sets it as the protobuf `IdempotencyKey` oneof. This only applies to `ReportResourceRequest`; other types are silently skipped.
+- `ParseDeleteMessage` does not extract transaction_id.
+- Operation dispatch in `ProcessMessage()` uses a switch on `headers.Operation`. Unknown operations log an error and are silently dropped (no error returned, no restart).
+- The `migration` operation type uses transforms from `consumer/transforms/` to convert legacy host format. See the transforms package guidelines for the transform functions. Migration checks `IsHostDeleted()` first, then dispatches to either delete or report resource transforms.
+
+## Kafka Consumer Configuration
+
+- `client.id` is hardcoded to `"kic"` (the `clientID` constant). Consumer group ID defaults to `"kic"`.
+- All Kafka timing settings are strings (milliseconds as string values), not integers. They are passed directly to `kafka.ConfigMap.SetKey()`.
+- `auto.offset.reset` defaults to `"earliest"` -- new consumer groups start from the beginning of the topic.
+- The `debug` setting is only added to the ConfigMap when non-empty.
+- `statistics.interval.ms` defaults to `"60000"`. Stats events (`*kafka.Stats`) are unmarshaled and fed to the metrics collector.
+
+## Metrics Integration
+
+- Most error paths call `metricscollector.Incr()` with the appropriate counter and operation label. Errors during initial setup (before the metrics collector exists) cannot be counted.
+- `Retry()` metrics labels require both `topic` and `suboperation` to be non-empty, or neither should be set. Setting only one adds noise.
+- Stats events from Kafka are collected via `MetricsCollector.Collect()`. Unmarshal failures are logged and counted but do not stop the consumer.
+
+## Testing Conventions
+
+- Use the `TestCase` struct and its `TestSetup()` method to bootstrap tests. This creates Options, Config, CompletedConfig, a MockConsumer, and an InventoryConsumer in one call.
+- Mock types live in `internal/mocks/mocks.go`: `MockConsumer` (implements the `Consumer` interface) and `MockClient` (implements `ClientProvider`). Both use testify/mock.
+- Replace `tester.inv.Consumer` and `tester.inv.Client` with mocks after `TestSetup()` when you need custom mock behavior.
+- Use `mock.Anything` for arguments you do not need to assert on. Use `.Maybe()` for methods that may or may not be called depending on race condition timing.
+- Table-driven tests are the standard pattern. Use `t.Run(test.name, ...)` for subtests.
+- Options tests use `common.AllOptionsHaveFlags()` to verify that every struct field with a `mapstructure` tag has a corresponding pflag registered. Pass sub-package field names (e.g., `"auth"`, `"retry-options"`) in the skip list since those are tested in their own packages.
+- Race condition tests (`race_condition_test.go`) test concurrent shutdown + rebalance and concurrent offset storage access using goroutines and channels. Run tests with `-race` flag.
+- Test message constants are defined at the top of `consumer_test.go` as package-level `const` values. Reuse these rather than creating new test fixtures when possible.

--- a/consumer/transforms/GUIDELINES.md
+++ b/consumer/transforms/GUIDELINES.md
@@ -1,0 +1,105 @@
+## Architecture
+
+This package converts Debezium CDC (Change Data Capture) messages from source systems into Kessel Inventory API v1beta2 protobuf request types. Each source system (called a "service provider") gets its own file containing transform functions. The consumer loop in `consumer.go` calls these transforms during `OperationTypeMigration` processing; standard `ReportResource`/`DeleteResource` operations use the generic parsers in `parsers.go` instead.
+
+Transforms are the extension point for onboarding new CDC source systems that do not emit pre-formatted Kessel API payloads.
+
+## Adding a New Service Provider
+
+1. **Create a domain type file** in `consumer/types/` (e.g., `edge_types.go`). Define:
+   - A message struct matching the Debezium CDC envelope (`Schema` + `Payload`).
+   - A payload struct with fields matching the source database columns.
+   - Constants for `ResourceType`, `ReporterType`, `ReporterInstanceID`, `APIHref`, `ConsoleHref`, and `ReporterVersion`. Follow the naming convention `<Provider>ResourceType`, `<Provider>ReporterType`, etc.
+   - Custom `UnmarshalJSON` implementations for any field that may arrive as either a JSON array or a JSON-encoded string (see `GroupSlice` for the pattern).
+
+2. **Create a transform file** in `consumer/transforms/` (e.g., `edge.go`). Implement exactly three exported functions following this naming pattern:
+   - `Transform<Provider>ToReportResourceRequest(msg []byte) (*v1beta2.ReportResourceRequest, error)` -- for create/update/migration upserts.
+   - `Transform<Provider>ToDeleteResourceRequest(msgValue []byte, msgKey []byte) (*v1beta2.DeleteResourceRequest, error)` -- for tombstone deletes.
+   - `Is<Provider>Deleted(msgValue []byte) (bool, error)` -- to detect tombstone messages.
+
+3. **Wire into the consumer** by adding a new case or routing logic in `ProcessMessage` (in `consumer.go`), gated on topic name or a header value that identifies the provider.
+
+## Transform Function Contracts
+
+### ReportResourceRequest Transform
+
+- Accept raw `[]byte` message value (the Kafka message value).
+- Unmarshal into the provider's domain type from `types/`.
+- Build an intermediate `map[string]interface{}` payload, then marshal/unmarshal through JSON into `v1beta2.ReportResourceRequest`. This round-trip is required because `Representations.Common` and `Representations.Reporter` are `*structpb.Struct` fields that only populate correctly via JSON deserialization.
+- The intermediate map must contain these top-level keys mapping to `ReportResourceRequest` fields:
+  - `"type"` -> resource type constant
+  - `"reporter_type"` -> reporter type constant
+  - `"reporter_instance_id"` -> reporter instance ID constant
+  - `"representations"` -> nested map with `"metadata"`, `"reporter"`, and `"common"` sub-maps
+- `metadata` sub-map must include `local_resource_id` (the source system's primary key), `api_href`, `console_href`, and `reporter_version`.
+- `reporter` sub-map holds provider-specific fields (e.g., `satellite_id`, `insights_id`).
+- `common` sub-map holds cross-reporter fields (e.g., `workspace_id`).
+
+### DeleteResourceRequest Transform
+
+- Accept both `msgValue []byte` and `msgKey []byte`. Tombstone messages have empty/null values, so the resource ID must be extracted from the message key.
+- Validate that the key is non-empty before attempting to unmarshal.
+- Return a `DeleteResourceRequest` with a fully populated `ResourceReference` containing `ResourceType`, `ResourceId`, and a `ReporterReference` with `Type` set.
+- Use an inline anonymous struct to unmarshal the key rather than importing a full domain type.
+
+### Deletion Detection (Is<Provider>Deleted)
+
+- Return `true` when `msgValue` is nil, empty, or the JSON literal `null`.
+- Use `isEmptyJSON` (unexported helper) for the null/whitespace check.
+- Always return `(bool, error)` even if the current implementation never returns an error -- the signature allows future implementations to inspect the value before deciding.
+
+## Null and Empty Value Handling
+
+- Use pointer types (`*string`) in domain structs for CDC columns that can be database NULL. JSON `null` deserializes to a nil pointer and flows through to `structpb.Struct` as a null value -- do not convert nil pointers to empty strings.
+- The `groups` field uses the custom `GroupSlice` type because Debezium may emit it as either a JSON array or a stringified JSON array. Any similar polymorphic field in a new provider must use a custom type with `UnmarshalJSON`.
+- **Collection access**: The current host transform (e.g., `hosts.go`) accesses collection elements like `Groups[0]` without validating length, which causes panics when the collection is empty. Future transform implementations should validate collection length before accessing elements and return an error, rather than relying on panic recovery.
+
+## Constants Conventions
+
+- Resource type constants are lowercase identifiers agreed upon with the Kessel Inventory team (e.g., `"host"`).
+- Reporter type constants are short abbreviations of the source system (e.g., `"hbi"` for Host Based Inventory).
+- Reporter instance ID is a fixed string identifying the deployment (e.g., `"redhat"`).
+- `APIHref` and `ConsoleHref` are placeholder URLs that may vary per environment in the future -- define them as constants now for consistency.
+- All constants live in the provider's `types/` file, not in the transforms package.
+
+## Relationship to parsers.go
+
+`parsers.go` handles messages that arrive already formatted as Kessel API request payloads (with `operation` and `version` headers). Transforms handle raw CDC messages that need structural conversion. The distinction:
+
+| Message source | Header `operation` | Processing path |
+|---|---|---|
+| Pre-formatted Kessel payload | `ReportResource` | `ParseCreateOrUpdateMessage` -> `v1beta2.ReportResourceRequest` |
+| Pre-formatted Kessel payload | `DeleteResource` | `ParseDeleteMessage` -> `v1beta2.DeleteResourceRequest` |
+| Raw CDC from source DB | `migration` | `transforms.IsHostDeleted` -> `TransformHostToReportResourceRequest` or `TransformHostToDeleteResourceRequest` |
+
+New providers consuming raw CDC will use the `migration` path (or a new operation type) and call their transform functions.
+
+## Testing Patterns
+
+### Structure
+- Use table-driven tests with the struct pattern: `name`, `message` (input bytes), `expectError`, `errorContains`, and `validate` (a function asserting on the output request).
+- Define test message JSON as package-level `const` strings with interpolated test UUID constants.
+- Define test UUIDs and error message substrings as package-level constants for reuse.
+
+### Required Test Cases for ReportResourceRequest Transforms
+1. Valid message with all fields populated -- verify every field on the output request.
+2. Message with null optional fields -- verify nil pointer fields propagate as null in the `structpb.Struct` maps (use `.AsMap()` and `assert.Nil`).
+3. Message with multiple items in a collection field -- verify the correct element is selected.
+4. Invalid JSON input -- verify error contains the unmarshal error prefix.
+5. Empty/missing required collections -- the current host transform panics on empty `Groups` (index-out-of-range); tests must use `defer/recover` to assert the panic. New transforms should return a descriptive error instead of panicking.
+6. Nil and empty byte slice inputs -- verify error returns.
+
+### Required Test Cases for DeleteResourceRequest Transforms
+1. Valid tombstone with a well-formed key -- verify `ResourceReference` fields.
+2. Empty key, nil key -- verify specific error messages.
+3. Invalid JSON in key -- verify error.
+4. Key with missing or empty ID field -- verify error.
+
+### Required Test Cases for Deletion Detection
+1. Empty byte slice, nil, `"null"` string -- all return `true`.
+2. Valid JSON, arbitrary non-empty bytes -- return `false`.
+
+### Assertions
+- Use `github.com/stretchr/testify/assert` for all assertions.
+- Access `structpb.Struct` field values via `.AsMap()` and assert with `assert.Equal` or `assert.Nil`.
+- For optional protobuf fields (pointer types like `*string`), dereference with `*field` in assertions.

--- a/internal/client/GUIDELINES.md
+++ b/internal/client/GUIDELINES.md
@@ -1,0 +1,118 @@
+## Architecture
+
+The `internal/client/` package wraps the Kessel Inventory gRPC API using the `kessel-sdk-go` SDK. It follows the Options -> Config -> CompletedConfig lifecycle pattern used throughout this project. The consumer loop interacts with the inventory API exclusively through the `ClientProvider` interface.
+
+## ClientProvider Interface
+
+`ClientProvider` is the sole contract between the consumer loop and the inventory API. All consumer code must depend on `ClientProvider`, never on `KesselClient` directly.
+
+The interface has three methods:
+- `ReportResource(*v1beta2.ReportResourceRequest) (*v1beta2.ReportResourceResponse, error)` -- create or update a resource
+- `DeleteResource(*v1beta2.DeleteResourceRequest) (*v1beta2.DeleteResourceResponse, error)` -- delete a resource
+- `IsEnabled() bool` -- gate all API calls; callers must check this before invoking ReportResource/DeleteResource
+
+When adding a new inventory API operation:
+1. Add the method to `ClientProvider` in `client.go`
+2. Implement it on `KesselClient` (delegate to the embedded `v1beta2.KesselInventoryServiceClient`)
+3. Add the method to `MockClient` in `internal/mocks/mocks.go`
+4. Add the corresponding operation constant and message processing case in `consumer/consumer.go`
+
+Every `ClientProvider` method that wraps a gRPC call must pass `context.Background()` to the underlying SDK stub and wrap errors with `fmt.Errorf("failed to <action>: %w", err)`.
+
+## Options / Config / CompletedConfig Lifecycle
+
+This pattern is shared across the codebase. For the client package:
+
+1. `NewOptions()` returns defaults (Enabled=true, Insecure=false, EnableOidcAuth=false)
+2. `Options.AddFlags(fs, prefix)` registers CLI flags with dot-delimited prefix (e.g., `client.url`)
+3. `Options.Complete()` runs completion logic (currently a no-op but must be called) and returns `[]error`
+4. `Options.Validate()` enforces constraints and returns `[]error`
+5. `NewConfig(options).Complete()` returns `(CompletedConfig, []error)`, producing a `CompletedConfig` passed to `New()`
+
+The caller in `cmd/start.go` must call Complete then Validate on Options before constructing the Config. The `CompletedConfig` struct uses a private inner `completedConfig` to prevent construction outside the Complete method.
+
+Every field in `Options` must have a corresponding flag registered in `AddFlags`. The test `TestOptions_AddFlags` uses `common.AllOptionsHaveFlags` to enforce this -- adding an Options field without a flag will fail the test.
+
+## Authentication Modes
+
+Three mutually exclusive modes exist, resolved in `New()`:
+
+| Mode | Flags | SDK Builder Call | Transport |
+|------|-------|-----------------|-----------|
+| Insecure | `Insecure=true, EnableOidcAuth=false` | `.Insecure().Build()` | No TLS |
+| TLS only | `Insecure=false, EnableOidcAuth=false` | `.Unauthenticated(channelCreds).Build()` | TLS with CA cert |
+| OIDC | `EnableOidcAuth=true, Insecure=false` | `.Authenticated(callCreds, channelCreds).Build()` | TLS + OAuth2 |
+
+Validation rule: `EnableOidcAuth=true` and `Insecure=true` cannot both be set. This is enforced in `Options.Validate()`.
+
+When `Enabled=false`, `New()` returns a `KesselClient` with a nil `KesselInventoryServiceClient` and `Enabled=false`. No connection is established.
+
+## kessel-sdk-go Usage
+
+The SDK dependency is `github.com/project-kessel/kessel-sdk-go`. Key imports:
+- `kessel/inventory/v1beta2` -- service client interface, request/response types, `NewClientBuilder`
+- `kessel/grpc` (aliased `kesselgrpc`) -- `OAuth2CallCredentials` for OIDC
+- `kessel/auth` -- `NewOAuth2ClientCredentials` for OAuth2 client credentials
+- `kessel/inventory/v1` -- health service client (used only in readyz, not in this package)
+
+Client construction always goes through `v1beta2.NewClientBuilder(url)` followed by one of the three auth mode builder chains. The builder returns `(client, conn, error)` -- the `conn` (`*grpc.ClientConn`) is currently discarded (noted as a TODO for connection lifecycle management).
+
+Do not construct gRPC connections manually for inventory API calls. Always use `NewClientBuilder`. The readyz command is the only place that constructs a raw `grpc.NewClient` connection, because it uses a different service (`v1.KesselInventoryHealthServiceClient`).
+
+## TLS Certificate Handling
+
+`configureTLS(caPath)` reads a CA cert file from disk and delegates to `configureTLSFromData(caCert)`. The split exists specifically so tests can use in-memory certificates via `configureTLSFromData` without touching the filesystem.
+
+When writing tests that need TLS credentials, use `createTestCACertData(t)` to generate a self-signed CA cert in memory, then call the `newWithCACertData` test helper or `configureTLSFromData` directly. Do not create temp cert files in tests.
+
+## Consumer Integration
+
+The consumer holds `ClientProvider` as the `Client` field on `InventoryConsumer`. The flow:
+1. `cmd/start.go` constructs `KesselClient` via `kessel.New(completedConfig, logger)`
+2. Passes it as `ClientProvider` to `consumer.Run(options, config, client, logger)`
+3. `Run()` internally constructs `InventoryConsumer` via `consumer.New(config, client, logger, nil)`
+4. In `ProcessMessage`, every API call is guarded by `i.Client.IsEnabled()` before invocation
+4. API calls are wrapped in `i.Retry(func() (interface{}, error) { ... })` for retry with backoff
+5. gRPC status codes are inspected via `status.FromError(err)` for specific error handling (e.g., `codes.NotFound` for delete operations causes message drop instead of retry)
+
+When adding new operations, follow the existing pattern: check `IsEnabled()`, wrap in `Retry()`, and handle domain-specific gRPC status codes with an `errorHandler` function.
+
+## Error Handling
+
+- All gRPC errors from `ClientProvider` methods are wrapped with `fmt.Errorf` context
+- The consumer's `Retry` mechanism handles transient failures with exponential backoff
+- For `DeleteResource`, `codes.NotFound` is treated as a non-error (message is dropped) via custom error handlers passed to `Retry`
+- When `Retry` exhausts max attempts, it returns `ErrMaxRetries`, which causes the consumer loop to restart
+
+## Testing
+
+Mock the `ClientProvider` interface using `mocks.MockClient` in `internal/mocks/mocks.go`. This mock uses `testify/mock` and implements all three interface methods.
+
+Pattern for testing consumer code that calls the client:
+```go
+mockClient := &mocks.MockClient{}
+mockClient.On("ReportResource", mock.Anything).Return(&v1beta2.ReportResourceResponse{}, nil)
+var client kessel.ClientProvider = mockClient
+```
+
+Pattern for testing client construction with TLS:
+```go
+caCertData := createTestCACertData(t)
+client, err := newWithCACertData(config, logger, caCertData)
+```
+
+When testing the `New()` constructor for disabled clients, verify that `KesselInventoryServiceClient` is nil and `Enabled` is false. For enabled clients, verify both fields are non-nil/true.
+
+## Health Check (readyz)
+
+The `readyz` command in `cmd/readyz.go` shares `kessel.Options` for URL and TLS configuration but does NOT use `ClientProvider` or `KesselClient`. It builds its own raw gRPC connection to call `v1.KesselInventoryHealthServiceClient.GetLivez`. This is intentional -- the health check uses a different API version (`v1` vs `v1beta2`) and a different service.
+
+The readyz TLS logic is simpler: if `CACertFile` is set, use TLS; otherwise use insecure. It does not support OIDC.
+
+## Key Invariants
+
+- `ClientProvider.IsEnabled()` must always be checked before calling `ReportResource` or `DeleteResource`
+- `EnableOidcAuth` and `Insecure` must never both be true (enforced by validation)
+- `InventoryURL` must be non-empty when `Enabled` is true (enforced by validation)
+- The `grpc.ClientConn` returned by the SDK builder is not managed; do not add connection pooling or lifecycle management without addressing the TODO in `New()`
+- The `readyz` command reuses `Options` for flag parsing but operates independently of `ClientProvider`

--- a/internal/client/GUIDELINES.md
+++ b/internal/client/GUIDELINES.md
@@ -72,8 +72,8 @@ The consumer holds `ClientProvider` as the `Client` field on `InventoryConsumer`
 2. Passes it as `ClientProvider` to `consumer.Run(options, config, client, logger)`
 3. `Run()` internally constructs `InventoryConsumer` via `consumer.New(config, client, logger, nil)`
 4. In `ProcessMessage`, every API call is guarded by `i.Client.IsEnabled()` before invocation
-4. API calls are wrapped in `i.Retry(func() (interface{}, error) { ... })` for retry with backoff
-5. gRPC status codes are inspected via `status.FromError(err)` for specific error handling (e.g., `codes.NotFound` for delete operations causes message drop instead of retry)
+5. API calls are wrapped in `i.Retry(func() (interface{}, error) { ... })` for retry with backoff
+6. gRPC status codes are inspected via `status.FromError(err)` for specific error handling (e.g., `codes.NotFound` for delete operations causes message drop instead of retry)
 
 When adding new operations, follow the existing pattern: check `IsEnabled()`, wrap in `Retry()`, and handle domain-specific gRPC status codes with an `errorHandler` function.
 

--- a/internal/config/GUIDELINES.md
+++ b/internal/config/GUIDELINES.md
@@ -19,7 +19,7 @@ Each configurable component uses a three-tier pattern spread across two files (o
 ### Lifecycle in Command Handlers
 
 The required call sequence in a command's `RunE` is:
-```
+```text
 options.Complete() -> options.Validate() -> NewConfig(options).Complete()
 ```
 Always check each step's error return before proceeding (when the method returns errors). See `cmd/start.go` for the canonical example.
@@ -47,7 +47,7 @@ Always check each step's error return before proceeding (when the method returns
 
 `AddFlags` receives a `prefix string`. If non-empty, prepend `prefix + "."` to every flag name. This creates the dot-separated hierarchy that Viper uses to map between YAML keys, flags, and env vars.
 
-```
+```text
 consumer.auth.sasl-mechanism   <-- flag name
 consumer:                      <-- YAML nesting
   auth:

--- a/internal/config/GUIDELINES.md
+++ b/internal/config/GUIDELINES.md
@@ -1,0 +1,127 @@
+## Options / Config / CompletedConfig Pattern
+
+Each configurable component uses a three-tier pattern spread across two files (or one file for simpler sub-packages):
+
+**`options.go`** defines:
+- `Options` struct -- user-facing settings with `mapstructure` tags. Holds only primitive/sub-Options fields.
+- `NewOptions()` -- returns `*Options` with sensible defaults hardcoded (not from config file).
+- `AddFlags(fs *pflag.FlagSet, prefix string)` -- registers every Options field as a CLI flag. Sub-options call their own `AddFlags` with an extended prefix.
+- `Validate() []error` (optional) -- returns a slice of errors for invalid combinations. Guard conditional checks on `Enabled` where applicable. Not all Options structs require this method (e.g., auth and retry sub-packages omit it).
+- `Complete() []error` (optional) -- post-processing hook for deriving values; return nil if nothing to derive. Not all Options structs require this method.
+
+**`config.go`** defines:
+- `Config` struct -- embeds `*Options` or holds it as a field, adds runtime objects (e.g., `*kafka.ConfigMap`).
+- `NewConfig(o *Options) *Config` -- wraps Options and builds sub-Configs from sub-Options.
+- `completedConfig` (unexported) -- the sealed, fully-resolved configuration. May embed `*Options` or hold it as a field.
+- `CompletedConfig` (exported) -- wraps `*completedConfig`. This is the only type consumers should accept, enforcing that `Complete()` was called.
+- `Complete()` -- transforms Config into CompletedConfig. Build derived runtime objects here (e.g., Kafka ConfigMap). Signature varies by package: top-level packages return `(CompletedConfig, []error)`, while some sub-packages (auth, retry) return just `CompletedConfig`. Return errors rather than panicking when the signature includes error return.
+
+### Lifecycle in Command Handlers
+
+The required call sequence in a command's `RunE` is:
+```
+options.Complete() -> options.Validate() -> NewConfig(options).Complete()
+```
+Always check each step's error return before proceeding (when the method returns errors). See `cmd/start.go` for the canonical example.
+
+### Adding a New Configurable Component
+
+1. Create `options.go` with `Options`, `NewOptions()`, `AddFlags()`, and optionally `Validate()` and `Complete()`.
+2. Create `config.go` with `Config`, `NewConfig()`, `completedConfig`, `CompletedConfig`, and `Complete()`.
+3. Add a `*yourpkg.Options` field to `internal/config/OptionsConfig` and initialize it in `NewOptionsConfig()`.
+4. Wire `AddFlags()` into the relevant command constructor (e.g., `startCommand`) using the appropriate prefix.
+5. Call `viper.BindPFlags(cmd.Flags())` in `cmd/root.go` `init()` after adding the command.
+6. Add the corresponding YAML section to `.inventory-consumer.yaml`.
+7. Write an `AllOptionsHaveFlags` test (see below).
+
+## mapstructure Tag Conventions
+
+- Every exported field on an Options struct must have a `mapstructure:"<key>"` tag.
+- Use lowercase kebab-case for tag values: `mapstructure:"bootstrap-servers"`, `mapstructure:"consumer-group-id"`.
+- The tag value must exactly match the flag name suffix registered in `AddFlags()` and the YAML key in the config file.
+- Sub-Options pointer fields use a tag matching the prefix passed to their `AddFlags()`: e.g., `*auth.Options` tagged `mapstructure:"auth"` corresponds to `AddFlags(fs, prefix+"auth")`.
+
+## Viper Binding and Flag Registration
+
+### AddFlags Prefix Protocol
+
+`AddFlags` receives a `prefix string`. If non-empty, prepend `prefix + "."` to every flag name. This creates the dot-separated hierarchy that Viper uses to map between YAML keys, flags, and env vars.
+
+```
+consumer.auth.sasl-mechanism   <-- flag name
+consumer:                      <-- YAML nesting
+  auth:
+    sasl-mechanism: ...
+```
+
+### Flag Binding in cmd/root.go
+
+Flags are registered on the *subcommand*, not the root. After `rootCmd.AddCommand(startCmd)`, call `viper.BindPFlags(startCmd.Flags())`. Root-level persistent flags (like `--config`) are bound separately on `rootCmd.PersistentFlags()`.
+
+### Environment Variable Limitation
+
+Viper's `AutomaticEnv()` replaces dots with underscores for env var lookup, but it does NOT replace hyphens. A flag named `consumer.bootstrap-servers` maps to env var `INVENTORY_CONSUMER_CONSUMER.BOOTSTRAP-SERVERS` -- which is not a valid shell variable name. Env var overrides only work reliably for keys that contain no hyphens. Do not promise env-var-based configuration for hyphenated keys without adding explicit `viper.BindEnv()` calls.
+
+The env prefix is set to the application name: `viper.SetEnvPrefix("inventory-consumer")`. Note that Viper does not replace hyphens in the prefix itself, so the resulting env var prefix is `INVENTORY-CONSUMER_` (with a hyphen), not `INVENTORY_CONSUMER_`. No `SetEnvKeyReplacer` is configured.
+
+## Config File Format and Search Paths
+
+- Format: YAML, file named `.inventory-consumer.yaml`.
+- Search order: (1) explicit `--config` flag, (2) `INVENTORY_CONSUMER_CONFIG` env var (resolved to absolute path), (3) current working directory, (4) user home directory.
+- Top-level YAML keys correspond to OptionsConfig field tags: `consumer`, `client`, `log`.
+- Nesting follows the mapstructure tags:
+  ```yaml
+  consumer:
+    auth:
+      enabled: false
+    retry-options:
+      consumer-max-retries: 3
+  client:
+    url: "localhost:9000"
+  ```
+- Viper unmarshals the entire file into `*OptionsConfig` via `viper.Unmarshal(&options)`.
+
+## OptionsConfig (internal/config)
+
+`OptionsConfig` is the top-level aggregation struct. It holds one `*Options` pointer per component:
+
+```go
+type OptionsConfig struct {
+    Consumer *consumer.Options
+    Client   *kessel.Options
+}
+```
+
+When adding a component, add a field here and initialize it in `NewOptionsConfig()`. The field name is not tagged -- Viper matches by the mapstructure tags on the nested struct.
+
+`LogConfigurationInfo()` is a standalone function (not a method) that logs non-secret config values at debug level. Update it when adding new components.
+
+## ClowdApp Config Injection
+
+- Runs in `cmd/root.go` `init()`, gated by `clowder.IsClowderEnabled()`.
+- Calls `options.InjectClowdAppConfig(clowder.LoadedConfig)` which mutates the already-constructed `OptionsConfig` in place.
+- `InjectClowdAppConfig` dispatches to per-component methods (e.g., `ConfigureConsumer`). Guard each with a nil check on the relevant AppConfig section.
+- Kafka SASL mapping from ClowdApp fields:
+  - `Brokers[0].SecurityProtocol` -> `AuthOptions.SecurityProtocol`
+  - `Brokers[0].Sasl.SaslMechanism` -> `AuthOptions.SASLMechanism`
+  - `Brokers[0].Sasl.Username` -> `AuthOptions.SASLUsername`
+  - `Brokers[0].Sasl.Password` -> `AuthOptions.SASLPassword`
+- Bootstrap servers are assembled from ALL brokers (`Hostname:Port`), not just the first.
+- SASL config is read only from `Brokers[0]`. Check `SecurityProtocol != nil` before accessing `Sasl`.
+
+## AllOptionsHaveFlags Test Helper
+
+`common.AllOptionsHaveFlags(t, prefix, fs, options, skippedFlags)` uses reflection to verify that every field in an Options struct (identified by its `mapstructure` tag) has a corresponding registered flag in the FlagSet.
+
+- Call it in every Options package's `TestOptions_AddFlags`.
+- Pass the same prefix used in `AddFlags`.
+- Pass `skippedFlags` for fields that are sub-Options pointers (they register their own flags via their own `AddFlags`). Example: `consumer.Options` skips `"auth"` and `"retry-options"`.
+- This test catches: (a) new fields added to Options without a corresponding flag, (b) mismatches between mapstructure tags and flag names.
+
+## Validation Rules
+
+- `Validate()` returns `[]error`, not a single error. Collect all validation failures rather than short-circuiting.
+- Place validation in `Options.Validate()` when the Options struct needs it, not in `Config.Complete()`. Complete handles construction; Validate handles correctness.
+- Not all Options structs require a `Validate()` method -- only those with validation rules (e.g., consumer, client).
+- Gate required-field checks on the component's `Enabled` flag when present (e.g., `BootstrapServers` is only required when `Enabled == true`).
+- Cross-field mutual exclusion belongs in Validate (e.g., `EnableOidcAuth && Insecure` is invalid in the client package).

--- a/metrics/GUIDELINES.md
+++ b/metrics/GUIDELINES.md
@@ -1,0 +1,130 @@
+## Metric Prefixes
+
+Two prefixes exist. Use the correct one based on the metric's origin:
+
+- `consumer_stats_` -- for metrics sourced from Kafka `Stats` callback messages (the `StatsData` struct). These are scraped from librdkafka's internal statistics.
+- `consumer_` -- for application-level counters that the consumer code increments directly (message processing, errors, etc.).
+
+Never invent a third prefix. All metric names in this package must start with one of these two constants (`statsPrefix`, `prefix`).
+
+## Naming Conventions
+
+- Use `snake_case` for all metric names after the prefix (e.g., `consumer_lag_stored`, not `consumerLagStored`).
+- Match the librdkafka stats JSON field name whenever the metric maps 1:1 to a stats field (e.g., `fetchq_cnt`, `rebalance_age`, `lo_offset`).
+- Do not add a unit suffix; Prometheus's `_total` suffix is appended automatically to counters by the OTel-Prometheus exporter.
+
+## MetricsCollector Struct
+
+`MetricsCollector` holds all OTel instruments. Rules:
+
+1. Every field must be either `metric.Int64Gauge` or `metric.Int64Counter`. No floats, no histograms.
+2. Stats-sourced fields (Kafka stats callback) are unexported (lowercase). App-level counters that are incremented from `consumer/` are exported (uppercase): `MsgsProcessed`, `MsgProcessFailures`, `ConsumerErrors`, `KafkaErrorEvents`.
+3. `subscribedTopics` stores the topic list passed at init time and is used in `Collect()` to iterate only over relevant topics.
+
+## Initialization Pattern
+
+Initialization is a method on `*MetricsCollector`, not a constructor returning a new value:
+
+```go
+var mc metricscollector.MetricsCollector
+err := mc.New(config.Topics)
+```
+
+Inside `New`:
+1. `NewMeterProvider()` creates a Prometheus exporter-backed `sdkmetric.MeterProvider` with service name `kessel-inventory-consumer`.
+2. `NewMeter(provider)` creates a meter scoped to `kessel-inventory-consumer`.
+3. Each field is registered on the meter. If registration fails, return immediately.
+4. Topics are stored in `m.subscribedTopics`.
+
+When adding a new metric, add the field to the struct AND register it in `New`. The existing test (`TestMetrics_New`) uses reflection to verify every field is non-zero after initialization -- a field added without registration will fail the test.
+
+## Choosing Gauge vs Counter
+
+- Use `Int64Gauge` for point-in-time values from Kafka stats: offsets, lag, queue sizes, state indicators, ages. Record with `.Record(ctx, value, labels)`.
+- Use `Int64Counter` for monotonically increasing values: messages processed, errors, rebalance count. Update with `.Add(ctx, value, labels)`. For stats-sourced counters, pass the absolute value from librdkafka (Prometheus computes deltas). For app-level counters, increment by 1 via the `Incr` helper.
+- Boolean-style state indicators (e.g., `fetchState`, `state`) are gauges recording `0` for the healthy state and `1` for any unhealthy state, with the actual state string as an attribute. For example, when `CGRP.State == "up"`, `consumer_stats_state` records `0` with attribute `state="up"`. The Grafana dashboard filters on the `state="up"` attribute to identify the consumer group -- the gauge value `0` indicates healthy.
+
+## The Incr Helper
+
+`Incr` is a package-level function for incrementing exported app-level counters by 1. It is the only way counters should be incremented from outside the package.
+
+```go
+metricscollector.Incr(i.MetricsCollector.MsgProcessFailures, "ParseHeaders", fmt.Errorf("missing headers"),
+    metricscollector.AddExtraLabel("topic", *e.TopicPartition.Topic))
+```
+
+Parameters:
+- `counter` -- one of the four exported `Int64Counter` fields on `MetricsCollector`.
+- `operation` -- a string identifying what was being attempted. Use the function or operation name (e.g., `"ParseHeaders"`, `"ReportResource"`, `"Retry"`).
+- `errReason` -- the error that caused the failure, or `nil`. When non-nil it is added as attribute `reason`.
+- `extraAttrs` -- optional additional `attribute.KeyValue` values. Build these with `AddExtraLabel(key, value)`.
+
+Rules for callers:
+- Always pass a descriptive `operation` string -- never empty.
+- Pass `errReason` only when the error message adds diagnostic value; pass `nil` for known/expected failure modes where the operation name alone is sufficient.
+- When a metric needs to be traceable to a specific topic, pass both `topic` and any relevant sub-label (e.g., `suboperation`). Pass either both or neither.
+
+## AddExtraLabel
+
+Use `metricscollector.AddExtraLabel(key, value)` to build extra attributes for `Incr`. Do not construct `attribute.KeyValue` manually unless you are in the `kafka.Error` handler (where `attribute.String` is used directly for `code` and `error` attributes).
+
+## Attribute Conventions
+
+Stats-sourced metrics (via `LabelSet`):
+- `name` -- Kafka client name (always present)
+- `client_id` -- Kafka client ID (always present)
+- `topic` -- topic name (present for partition-level metrics, empty string for top-level/cgrp)
+- `partition` -- partition key string (present for partition-level metrics, empty string for top-level/cgrp)
+- Additional state attributes: `fetch_state`, `state`, `last_rebalance_reason` are added inline where applicable.
+
+App-level counters (via `Incr`):
+- `operation` -- always present, identifies the operation or function.
+- `reason` -- present only when `errReason != nil`.
+- `topic` -- added via `AddExtraLabel` when the failure is traceable to a topic.
+- `suboperation` -- added via `AddExtraLabel` in retry paths to distinguish the underlying call.
+- `code`, `error` -- used on `KafkaErrorEvents` for Kafka error events.
+
+## Collect Method
+
+`Collect(stats StatsData)` is called on every `kafka.Stats` event. It:
+1. Records top-level metrics with `LabelSet("", "")` (no topic/partition).
+2. Iterates `m.subscribedTopics`, then each partition within each topic. Partitions with key `"-1"` (aggregate) are skipped.
+3. Records CGRP metrics with `LabelSet("", "")` plus inline state attributes.
+
+When adding a new stats-based metric, follow this flow: add field to `StatsData`/sub-struct, add gauge/counter to `MetricsCollector`, register in `New`, record in `Collect` at the appropriate nesting level.
+
+## Prometheus HTTP Server
+
+`ServeMetrics()` serves the Prometheus `/metrics` endpoint on port `9000`. It is launched as a goroutine from `cmd/start.go`. It uses the default `http.ServeMux`. Do not register other handlers on the default mux. The port is hardcoded; if it needs to become configurable, it should move to the options/config pattern used by the consumer.
+
+## Kafka Stats Callback Integration
+
+The consumer enables librdkafka stats by setting `statistics.interval.ms` in the Kafka config. Stats arrive as `*kafka.Stats` events in the poll loop. The consumer unmarshals the JSON into `StatsData` and calls `Collect()`. If unmarshalling fails, it increments `MsgProcessFailures` with operation `"StatsCollection"` and continues (does not break the loop).
+
+## Grafana Dashboard Alignment
+
+The dashboard in `dashboards/grafana-dashboard-kessel-inventory-consumer.configmap.yaml` queries these exact Prometheus metric names (with `_total` suffix auto-appended to counters):
+
+| Dashboard panel | Metric queried |
+|---|---|
+| Active Consumers | `consumer_stats_state{state="up"}` |
+| Msgs in Queue | `consumer_stats_replyq` |
+| Last Rebalance | `consumer_stats_rebalance_age` |
+| Rebalance Events | `consumer_stats_rebalance_cnt_total` |
+| Consumer Processing Rate | `consumer_msgs_processed_total` |
+| Consumer Processing Failure Rate | `consumer_msg_process_failures_total / consumer_msgs_processed_total` |
+| Consumer Error Rate | `consumer_errors_total / consumer_msgs_processed_total` |
+| Kafka Error Events | `consumer_kafka_error_events_total` |
+| HBI Processed Events | `consumer_msgs_processed_total{topic="outbox.event.hbi.hosts"}` |
+
+When adding or renaming a metric, update the dashboard ConfigMap to match. When adding a `topic` label to a counter, verify per-topic panels still aggregate correctly.
+
+## Testing
+
+The test in `metricscollector_test.go` uses reflection to verify that every field on `MetricsCollector` is non-zero after `New()`. This means:
+
+1. Any new field added to `MetricsCollector` will automatically be caught if not initialized.
+2. Tests cover both single-topic and multi-topic initialization.
+3. The test validates field count parity between the type definition and the instantiated struct.
+
+When adding new metrics, the existing test will fail if the field is not registered in `New` -- no additional test case is needed for initialization.

--- a/metrics/GUIDELINES.md
+++ b/metrics/GUIDELINES.md
@@ -41,7 +41,7 @@ When adding a new metric, add the field to the struct AND register it in `New`. 
 ## Choosing Gauge vs Counter
 
 - Use `Int64Gauge` for point-in-time values from Kafka stats: offsets, lag, queue sizes, state indicators, ages. Record with `.Record(ctx, value, labels)`.
-- Use `Int64Counter` for monotonically increasing values: messages processed, errors, rebalance count. Update with `.Add(ctx, value, labels)`. For stats-sourced counters, pass the absolute value from librdkafka (Prometheus computes deltas). For app-level counters, increment by 1 via the `Incr` helper.
+- Use `Int64Counter` for monotonically increasing values: messages processed, errors, rebalance count. Update with `.Add(ctx, value, labels)`. For app-level counters, increment by 1 via the `Incr` helper. Note: `rebalanceCnt` currently passes the cumulative value from librdkafka directly to `Int64Counter.Add()` on each stats callback, which double-counts because `Add()` is additive. New stats-sourced counters should either compute the delta between successive callbacks or use an `Int64Gauge` with `.Record()` for cumulative values.
 - Boolean-style state indicators (e.g., `fetchState`, `state`) are gauges recording `0` for the healthy state and `1` for any unhealthy state, with the actual state string as an attribute. For example, when `CGRP.State == "up"`, `consumer_stats_state` records `0` with attribute `state="up"`. The Grafana dashboard filters on the `state="up"` attribute to identify the consumer group -- the gauge value `0` indicates healthy.
 
 ## The Incr Helper


### PR DESCRIPTION
Add AI agent guidelines, CLAUDE.md, and CodeRabbit config
* Added GUIDELINES.md files in consumer/, consumer/transforms/, internal/client/, internal/config/, and metrics/ with verified, code-accurate conventions for each subsystem
* Added AGENTS.md at the repo root as the central onboarding doc for AI agents; covers architecture, cross-cutting conventions, and indexes all guideline files
* Added CLAUDE.md as a thin Claude Code-specific layer with build/test/lint commands and an @AGENTS.md import
* Added .coderabbit.yaml to point CodeRabbit at the guideline files during PR reviews, with org-wide learnings enabled
* Updated README.md with a project structure overview and links to all documentation

The changes in this PR were generated by the `/agent-readiness` Claude skill from https://github.com/gwenneg/claude-engineering-toolkit with some modifications to ensure coderabbit optimization by not nesting all  guidelines under a docs/ path similar to recent work done for Inventory API. All guideline content was explored from the actual codebase, then independently verified against the code for accuracy. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive set of repository guidelines covering contributor onboarding, subsystem architecture, configuration patterns, error-handling expectations, and testing conventions.
  * Expanded the README with a clearer “Project Structure” overview and direct links to the new subsystem and dev/deployment documentation.
  * Updated/added detailed consumer, CDC transform, internal client/config, and metrics guideline references, including clarified metric naming/labeling rules and Prometheus/Grafana alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->