### PR TITLE
NOJIRA-12345 - Disable go-kratos major updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,13 @@
           "branchTopic": "go-updates",
           "commitMessageTopic": "go packages"
         }
+      },
+      {
+        "description": "Disable go-kratos major updates",
+        "matchManagers": ["gomod"],
+        "matchPackageNames": ["github.com/go-kratos/**"],
+        "matchUpdateTypes": ["major"],
+        "enabled": false
       }
     ]
   }


### PR DESCRIPTION
Currently https://github.com/project-kessel/inventory-consumer/pull/359 is blocked by a major update of kratos which is being postponed for the time being

npx --yes --package renovate -- renovate-config-validator
```
 INFO: Validating .github/renovate.json
 INFO: Config validated successfully
```

Similar to config in [inventory-api](https://github.com/project-kessel/inventory-api/blob/main/.github/renovate.json)

JIRA for handling future migration: https://redhat.atlassian.net/browse/RHCLOUD-49625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings for Go modules.
  * Major-version updates for selected Go Kratos modules are now excluded from automated handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->